### PR TITLE
Add generic HMM test utility and integration tests

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 DensityInterface = "b429d917-457f-4dbc-8f4c-0cc954292b1d"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 HiddenMarkovModels = "84ca31d5-effc-45e0-bfda-5a68cd981f47"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"

--- a/test/hmm_utils.jl
+++ b/test/hmm_utils.jl
@@ -1,24 +1,91 @@
-"""
-    create_hmm()
+using EmissionModels
+using Distributions
+using HiddenMarkovModels
+using Random
+using LinearAlgebra
 
-Utility to create a 3 state HMM for testing purposes. 
-"""
-function create_hmm()
-    # Define HMM params
-    α = 10.0
+function create_hmm(
+    emission_model_type; n_states=3, α=10.0, rng=Random.GLOBAL_RNG, kwargs...
+)
+    # Initialize transition matrix and initial distribution
+    trans = Matrix{Float64}(undef, n_states, n_states)
 
-    trans = zeros(undef, 3, 3)
-    init = zeros(undf, 3)
-
-    # fill transition matrix
-    for i in 1:3
-        dir_vector = zeros(3)
-        dir_vector[i] = α # make sticky!
-        trans[i, :] = rand(Dirichlet(dir_vector))
+    # Fill transition matrix with sticky transitions
+    for i in 1:n_states
+        dir_vector = ones(n_states)
+        dir_vector[i] = α  # Make diagonal sticky!
+        trans[i, :] = rand(rng, Dirichlet(dir_vector))
     end
 
-    # fill initial distribution
-    return init = rand(Dirichlet(ones(3)))
+    # Fill initial distribution (uniform Dirichlet)
+    init = rand(rng, Dirichlet(ones(n_states)))
 
-    # Define Emission Models
+    # Create emission models for each state
+    emissions = _create_emissions(emission_model_type, n_states, rng; kwargs...)
+
+    # Create and return the HMM
+    return HMM(init, trans, emissions)
+end
+
+function _create_emissions(
+    ::Type{PoissonZeroInflated},
+    n_states,
+    rng;
+    λ_range=(1.0, 10.0),
+    π_range=(0.1, 0.4),
+    kwargs...,
+)
+    emissions = Vector{PoissonZeroInflated}(undef, n_states)
+    for i in 1:n_states
+        λ = rand(rng) * (λ_range[2] - λ_range[1]) + λ_range[1]
+        π = rand(rng) * (π_range[2] - π_range[1]) + π_range[1]
+        emissions[i] = PoissonZeroInflated(λ, π)
+    end
+    return emissions
+end
+
+function _create_emissions(
+    ::Type{MultivariateT}, n_states, rng; dim=2, ν_range=(3.0, 10.0), kwargs...
+)
+    emissions = Vector{MultivariateT}(undef, n_states)
+    for i in 1:n_states
+        # Random mean vector
+        μ = randn(rng, dim) .* 2.0
+
+        # Random positive definite covariance matrix
+        A = randn(rng, dim, dim)
+        Σ = A' * A + I  # Ensure positive definite
+        Σ = (Σ + Σ') / 2  # Ensure symmetric
+
+        # Random degrees of freedom
+        ν = rand(rng) * (ν_range[2] - ν_range[1]) + ν_range[1]
+
+        emissions[i] = MultivariateT(μ, Σ, ν)
+    end
+    return emissions
+end
+
+function _create_emissions(
+    ::Type{MultivariateTDiag},
+    n_states,
+    rng;
+    dim=2,
+    ν_range=(3.0, 10.0),
+    σ²_range=(0.5, 2.0),
+    kwargs...,
+)
+    emissions = Vector{MultivariateTDiag}(undef, n_states)
+    for i in 1:n_states
+        # Random mean vector
+        μ = randn(rng, dim) .* 2.0
+
+        # Random diagonal variances
+        σ² = rand(rng, dim) .* (σ²_range[2] - σ²_range[1]) .+ σ²_range[1]
+
+        # Random degrees of freedom
+        ν = rand(rng) * (ν_range[2] - ν_range[1]) + ν_range[1]
+
+        emissions[i] = MultivariateTDiag(μ, σ², ν)
+    end
+    return emissions
 end


### PR DESCRIPTION
Refactor and generalize the HMM creation utility in test/hmm_utils.jl to support different emission models and parameters. Add comprehensive HMM integration tests for MultivariateT, MultivariateTDiag, and PoissonZeroInflated emissions in their respective test files, verifying HMM structure, emission types, stochasticity, sampling, and Baum-Welch fitting. Update test/Project.toml to include Distributions as a test dependency.