### PR TITLE
Fix correctness issues in constructors, sampling, and Float32 handling

### DIFF
--- a/src/glms/glm.jl
+++ b/src/glms/glm.jl
@@ -85,7 +85,7 @@ exact MAP solution for a Gaussian prior β ~ N(0, (1/λ)I).
 
 # Fields
 - `β`: coefficient vector (length p)
-- `σ2`: noise variance
+- `σ2`: noise variance (must be positive)
 - `prior`: regularization prior (default `NoPrior()`)
 """
 mutable struct GaussianGLM{T<:Real,P<:AbstractPrior} <: AbstractGLM
@@ -95,6 +95,7 @@ mutable struct GaussianGLM{T<:Real,P<:AbstractPrior} <: AbstractGLM
     function GaussianGLM{T,P}(
         β::Vector{T}, σ2::T, prior::P
     ) where {T<:Real,P<:AbstractPrior}
+        σ2 > 0 || throw(ArgumentError("σ2 must be positive, got $σ2"))
         return new{T,P}(β, σ2, prior)
     end
 end

--- a/src/multivariate/t.jl
+++ b/src/multivariate/t.jl
@@ -46,7 +46,9 @@ mutable struct MultivariateT{T<:Real}
 
         logdetΣ = logdet(Σ_chol)
 
-        return new{T}(μ, Σ, ν, Σ_chol, logdetΣ, dim)
+        #= Copy μ and Σ so the struct never aliases caller arrays: an external
+           mutation of Σ would silently desync the cached Cholesky/logdetΣ. =#
+        return new{T}(copy(μ), copy(Σ), ν, Σ_chol, logdetΣ, dim)
     end
 end
 
@@ -104,7 +106,9 @@ mutable struct MultivariateTDiag{T<:Real}
 
         logdetΣ = sum(log, σ²)
 
-        return new{T}(μ, σ², ν, logdetΣ, dim)
+        # Copy so the struct never aliases caller arrays (mutating σ² externally
+        # would silently desync the cached logdetΣ).
+        return new{T}(copy(μ), copy(σ²), ν, logdetΣ, dim)
     end
 end
 
@@ -128,8 +132,14 @@ DensityInterface.DensityKind(::MultivariateTDiag) = DensityInterface.HasDensity(
    only in how `mahal²` and `logdetΣ` are formed, so the normalisation constant
    and the `log1p` tail are defined here once. =#
 function _t_logpdf(ν, d, logdetΣ, mahal²)
-    log_norm = loggamma((ν + d) / 2) - loggamma(ν / 2) - (d / 2) * log(ν * π) - logdetΣ / 2
-    return log_norm - ((ν + d) / 2) * log1p(mahal² / ν)
+    #= Work in the common float type of the inputs; `d` enters via T(d) so the
+       integer never promotes a Float32 computation to Float64. =#
+    T = float(promote_type(typeof(ν), typeof(logdetΣ), typeof(mahal²)))
+    νT = T(ν)
+    half_νd = (νT + T(d)) / 2
+    log_norm =
+        loggamma(half_νd) - loggamma(νT / 2) - (T(d) / 2) * log(νT * T(π)) - T(logdetΣ) / 2
+    return log_norm - half_νd * log1p(T(mahal²) / νT)
 end
 
 """
@@ -198,6 +208,17 @@ function Random.rand(rng::AbstractRNG, dist::MultivariateTDiag)
     u = rand(rng, Chisq(dist.ν))
     z = randn(rng, dist.dim)
     return dist.μ .+ sqrt(dist.ν / u) .* sqrt.(dist.σ²) .* z
+end
+
+#= Array forms (`rand(dist, n)` etc.) go through Random's sampler machinery,
+   which needs the sample eltype and a method on the default trivial sampler.
+   Samples are length-`dim` vectors, matching the obs_seq convention. =#
+Base.eltype(::Type{MultivariateT{T}}) where {T<:Real} = Vector{T}
+Base.eltype(::Type{MultivariateTDiag{T}}) where {T<:Real} = Vector{T}
+function Random.rand(
+    rng::AbstractRNG, sp::Random.SamplerTrivial{<:Union{MultivariateT,MultivariateTDiag}}
+)
+    return rand(rng, sp[])
 end
 
 #= ECME degrees-of-freedom update, shared by the `MultivariateT` and

--- a/src/zeroinflated/poisson.jl
+++ b/src/zeroinflated/poisson.jl
@@ -79,6 +79,13 @@ function Random.rand(rng::Random.AbstractRNG, dist::PoissonZeroInflated)
     end
 end
 
+#= Array forms (`rand(dist, n)` etc.) go through Random's sampler machinery,
+   which needs the sample eltype and a method on the default trivial sampler. =#
+Base.eltype(::Type{<:PoissonZeroInflated}) = Int
+function Random.rand(rng::AbstractRNG, sp::Random.SamplerTrivial{<:PoissonZeroInflated})
+    return rand(rng, sp[])
+end
+
 # Parameter estimation
 """
 	fit!(dist::PoissonZeroInflated, obs_seq, weight_seq)

--- a/test/glm/gaussian.jl
+++ b/test/glm/gaussian.jl
@@ -290,3 +290,11 @@ end
         @test_throws DimensionMismatch fit!(glm, wrong_dim_obs, ones(5); control_seq=X)
     end
 end
+
+@testset "GaussianGLM rejects non-positive σ2" begin
+    @test_throws ArgumentError GaussianGLM([1.0, 2.0], -2.0)
+    @test_throws ArgumentError GaussianGLM([1.0, 2.0], 0.0)
+    @test_throws ArgumentError GaussianGLM([1.0, 2.0], -1.0, RidgePrior(0.5))
+    # Positive σ2 still constructs fine, including through the promoting path.
+    @test GaussianGLM([1, 2], 1) isa GaussianGLM{Float64,NoPrior}
+end

--- a/test/multivariate/test_t.jl
+++ b/test/multivariate/test_t.jl
@@ -548,3 +548,47 @@ end
         @test all(all(1.0 .<= dist.σ² .<= 3.0) for dist in hmm_custom.dists)
     end
 end
+
+@testset "Constructor does not alias caller arrays" begin
+    μ = [0.0, 0.0]
+    Σ = [1.0 0.3; 0.3 1.0]
+    dist = MultivariateT(μ, Σ, 5.0)
+    lp_before = logdensityof(dist, [0.1, 0.2])
+    # Mutating the caller's arrays must not affect the (cached) distribution.
+    Σ[1, 1] = 100.0
+    μ[1] = 50.0
+    @test dist.Σ[1, 1] == 1.0
+    @test dist.μ[1] == 0.0
+    @test logdensityof(dist, [0.1, 0.2]) == lp_before
+
+    σ² = [1.0, 2.0]
+    μd = [0.0, 0.0]
+    distd = MultivariateTDiag(μd, σ², 5.0)
+    lp_before_d = logdensityof(distd, [0.1, 0.2])
+    σ²[1] = 100.0
+    μd[1] = 50.0
+    @test distd.σ²[1] == 1.0
+    @test logdensityof(distd, [0.1, 0.2]) == lp_before_d
+end
+
+@testset "Array sampling API" begin
+    rng = Random.MersenneTwister(42)
+    dist = MultivariateT([0.0, 0.0], [1.0 0.3; 0.3 1.0], 5.0)
+    samples = rand(rng, dist, 10)
+    @test samples isa Vector{Vector{Float64}}
+    @test length(samples) == 10
+    @test all(length(s) == 2 for s in samples)
+
+    distd = MultivariateTDiag([0.0, 0.0], [1.0, 2.0], 5.0)
+    samples_d = rand(rng, distd, 10)
+    @test samples_d isa Vector{Vector{Float64}}
+    @test length(samples_d) == 10
+end
+
+@testset "Float32 type stability" begin
+    dist = MultivariateT(Float32[0, 0], Float32[1 0; 0 1], 5.0f0)
+    @test logdensityof(dist, Float32[0.1, 0.2]) isa Float32
+
+    distd = MultivariateTDiag(Float32[0, 0], Float32[1, 1], 5.0f0)
+    @test logdensityof(distd, Float32[0.1, 0.2]) isa Float32
+end

--- a/test/zeroinflated/test_poisson.jl
+++ b/test/zeroinflated/test_poisson.jl
@@ -230,3 +230,14 @@ include("../hmm_utils.jl")
         @test all(0.2 <= dist.π <= 0.5 for dist in hmm_custom.dists)
     end
 end
+
+@testset "Array sampling API" begin
+    rng = Random.MersenneTwister(42)
+    dist = PoissonZeroInflated(3.0, 0.2)
+    samples = rand(rng, dist, 100)
+    @test samples isa Vector{Int}
+    @test length(samples) == 100
+    @test all(s >= 0 for s in samples)
+    # The docstring form without an explicit rng.
+    @test rand(dist, 5) isa Vector{Int}
+end


### PR DESCRIPTION
- `MultivariateT`/`MultivariateTDiag` now copy their array arguments; mutating the caller's `Σ` used to silently desync the cached Cholesky.
- `GaussianGLM` rejects `σ2 ≤ 0` at construction.
- `rand(dist, n)` works now for `PoissonZeroInflated` and the t-types (was a `MethodError`).
- `_t_logpdf` no longer promotes Float32 inputs to Float64.

Tests added for each.