### PR TITLE
ACDC: rng threading and robustness fixes

### DIFF
--- a/docs/src/acdc.md
+++ b/docs/src/acdc.md
@@ -43,8 +43,9 @@ changes.
 ## Custom emissions
 
 To use ACDC with an emission type that is not a standard `Distributions` object,
-add a method `EmissionModels._emission_to_driver(dist, obs)` returning the driver
-vector in ``[0,1]``.
+add a method `EmissionModels._emission_to_driver(rng, dist, obs)` returning the
+driver vector in ``[0,1]``. Draw any randomness (e.g. for a randomized PIT) from
+`rng` so driver recovery stays reproducible.
 
 ## API Reference
 

--- a/src/acdc/drivers.jl
+++ b/src/acdc/drivers.jl
@@ -16,23 +16,24 @@
      through its conditional Student-t CDF. (A Gaussian-style whiten-then-Φ is
      wrong here: whitened t-coordinates are uncorrelated but not independent.)
    - GLMs (`AbstractGLM`): conditional emissions f(y | x). Recovered through a
-     3-arg `_emission_to_driver(dist, obs, x)` that reduces the GLM at covariate
-     `x` to the standard emission it is (Normal / Bernoulli / Poisson / MvNormal)
-     and reuses the recipes above.
+     4-arg `_emission_to_driver(rng, dist, obs, x)` that reduces the GLM at
+     covariate `x` to the standard emission it is (Normal / Bernoulli / Poisson /
+     MvNormal) and reuses the recipes above.
 
    These methods dispatch on `Distributions` types and the package's own emission
    types, so ACDC works with any HiddenMarkovModels.jl HMM whose emissions are
    standard distributions or those types. To support a further custom emission
-   type, add a `_emission_to_driver(dist, obs)` method (or the 3-arg form for a
-   covariate-dependent emission) returning a `Vector` of drivers in [0,1]. =#
+   type, add a `_emission_to_driver(rng, dist, obs)` method (or the 4-arg form
+   for a covariate-dependent emission) returning a `Vector` of drivers in [0,1].
+   The `rng` feeds the randomized PITs so driver recovery is reproducible. =#
 
 # Clamp a PIT value strictly inside (0,1); the discrepancy measures map drivers
 # through the probit transform, which is ±Inf at the boundary.
 _clamp01(u::T) where {T<:Real} = clamp(u, eps(T), one(T) - eps(T))
 
 # Draw a category index from probability vector `p` (assumed to sum to ≈1).
-function _sample_categorical(p::AbstractVector{T}) where {T<:Real}
-    u = rand(T)
+function _sample_categorical(rng::AbstractRNG, p::AbstractVector{T}) where {T<:Real}
+    u = rand(rng, T)
     cumsum_p = zero(T)
     for i in eachindex(p)
         cumsum_p += p[i]
@@ -45,22 +46,22 @@ end
 # Returns a length-`D` vector of values in (0,1).
 function _emission_to_driver end
 
-# Continuous univariate: standard PIT through the CDF.
-function _emission_to_driver(d::ContinuousUnivariateDistribution, obs::Real)
+# Continuous univariate: standard PIT through the CDF (no randomness needed).
+function _emission_to_driver(::AbstractRNG, d::ContinuousUnivariateDistribution, obs::Real)
     return [_clamp01(float(cdf(d, obs)))]
 end
 
 # Discrete univariate: randomized PIT, ε ~ U(F(x⁻), F(x)).
-function _emission_to_driver(d::DiscreteUnivariateDistribution, obs::Real)
+function _emission_to_driver(rng::AbstractRNG, d::DiscreteUnivariateDistribution, obs::Real)
     upper = float(cdf(d, obs))
     lower = float(cdf(d, obs - 1))
-    return [_clamp01(lower + rand() * (upper - lower))]
+    return [_clamp01(lower + rand(rng) * (upper - lower))]
 end
 
 # Multivariate normal: Rosenblatt transform = whiten residual, then push each
 # whitened coordinate through Φ. Whitening with the lower-Cholesky factor yields
 # independent N(0,1) coordinates, so the result is uniform under the true model.
-function _emission_to_driver(d::AbstractMvNormal, obs::AbstractVector)
+function _emission_to_driver(::AbstractRNG, d::AbstractMvNormal, obs::AbstractVector)
     μ = mean(d)
     L = cholesky(Symmetric(Matrix(cov(d)))).L
     z = L \ (collect(float.(obs)) .- μ)
@@ -70,11 +71,11 @@ end
 # Zero-inflated Poisson: randomized PIT against the ZIP CDF. The mixture CDF is
 # F(k) = π + (1-π)·F_Poisson(k) for k ≥ 0; the structural-zero mass collapses
 # into F(0), so a true zero still maps uniformly into [0, F(0)].
-function _emission_to_driver(d::PoissonZeroInflated, obs::Real)
+function _emission_to_driver(rng::AbstractRNG, d::PoissonZeroInflated, obs::Real)
     pois = Poisson(d.λ)
     upper = d.π + (1 - d.π) * cdf(pois, obs)
     lower = obs > 0 ? d.π + (1 - d.π) * cdf(pois, obs - 1) : zero(upper)
-    return [_clamp01(float(lower + rand() * (upper - lower)))]
+    return [_clamp01(float(lower + rand(rng) * (upper - lower)))]
 end
 
 # Multivariate Student-t (full and diagonal scale): the conditional-t Rosenblatt
@@ -83,12 +84,12 @@ end
 # independent — pushing each through Φ (as for a Gaussian) would be wrong. The
 # correct map sends each whitened coordinate through its conditional Student-t
 # CDF, which has ν+(j-1) degrees of freedom and scale √((ν+Σ_{i<j} zᵢ²)/(ν+j-1)).
-function _emission_to_driver(d::MultivariateT, obs::AbstractVector)
+function _emission_to_driver(::AbstractRNG, d::MultivariateT, obs::AbstractVector)
     z = d.Σ_chol.L \ (collect(float.(obs)) .- d.μ)
     return _conditional_t_drivers(z, d.ν)
 end
 
-function _emission_to_driver(d::MultivariateTDiag, obs::AbstractVector)
+function _emission_to_driver(::AbstractRNG, d::MultivariateTDiag, obs::AbstractVector)
     z = (collect(float.(obs)) .- d.μ) ./ sqrt.(d.σ²)
     return _conditional_t_drivers(z, d.ν)
 end
@@ -113,7 +114,7 @@ F(y | x). Rather than re-deriving a randomized PIT per family, we reduce each
 GLM at covariate `x` to the standard `Distributions` emission it is, then route
 through the recipes above. 
 
-The covariate reaches drivers via a 3-arg `_emission_to_driver(dist, obs, x)`.
+The covariate reaches drivers via a 4-arg `_emission_to_driver(rng, dist, obs, x)`.
 The generic method ignores `x`, so every non-GLM emission (Normal, ZIP, MvT, …)
 is unaffected; only GLMs override it.
 =#
@@ -125,32 +126,38 @@ _conditional(g::BernoulliGLM, x) = Bernoulli(logistic(dot(g.β, x)))
 _conditional(g::PoissonGLM, x) = Poisson(exp(dot(g.β, x)))
 _conditional(g::MvGaussianGLM, x) = MvNormal(g.B' * x, g.Σ)
 
-# Generic 3-arg form: covariate ignored (all non-GLM emissions defer here).
-_emission_to_driver(dist, obs, control) = _emission_to_driver(dist, obs)
+# Generic 4-arg form: covariate ignored (all non-GLM emissions defer here).
+function _emission_to_driver(rng::AbstractRNG, dist, obs, control)
+    return _emission_to_driver(rng, dist, obs)
+end
 
 # Univariate and correlated-multivariate (Gaussian) GLMs: reduce, then reuse the
 # conditional PIT. MvGaussianGLM has correlated outputs ⇒ the MvNormal Rosenblatt.
-_emission_to_driver(g::AbstractGLM, obs, x) = _emission_to_driver(_conditional(g, x), obs)
+function _emission_to_driver(rng::AbstractRNG, g::AbstractGLM, obs, x)
+    return _emission_to_driver(rng, _conditional(g, x), obs)
+end
 
 # Independent-by-column multivariate GLMs: stack per-coordinate randomized PITs.
 # The columns are independent given `x`, so the stacked drivers are genuinely
 # independent uniforms — no joint Rosenblatt needed.
-function _emission_to_driver(g::MvBernoulliGLM, obs::AbstractVector, x)
+function _emission_to_driver(rng::AbstractRNG, g::MvBernoulliGLM, obs::AbstractVector, x)
     η = g.B' * x
-    return [_emission_to_driver(Bernoulli(logistic(η[j])), obs[j])[1] for j in eachindex(η)]
+    return [
+        _emission_to_driver(rng, Bernoulli(logistic(η[j])), obs[j])[1] for j in eachindex(η)
+    ]
 end
 
-function _emission_to_driver(g::MvPoissonGLM, obs::AbstractVector, x)
+function _emission_to_driver(rng::AbstractRNG, g::MvPoissonGLM, obs::AbstractVector, x)
     η = g.B' * x
-    return [_emission_to_driver(Poisson(exp(η[j])), obs[j])[1] for j in eachindex(η)]
+    return [_emission_to_driver(rng, Poisson(exp(η[j])), obs[j])[1] for j in eachindex(η)]
 end
 
-# 2-arg form on a GLM: no covariate to condition on — point at the 3-arg hook.
-function _emission_to_driver(g::AbstractGLM, obs)
+# 3-arg form on a GLM: no covariate to condition on — point at the 4-arg hook.
+function _emission_to_driver(::AbstractRNG, g::AbstractGLM, obs)
     throw(
         ArgumentError(
             "GLM emission $(typeof(g)) is conditional on a covariate — call " *
-            "`EmissionModels._emission_to_driver(glm, obs, control)` with the " *
+            "`EmissionModels._emission_to_driver(rng, glm, obs, control)` with the " *
             "covariate vector for that observation.",
         ),
     )
@@ -158,15 +165,15 @@ end
 
 # Clear error for emission types without a PIT recipe, pointing the user at the
 # extension hook.
-function _emission_to_driver(d, obs)
+function _emission_to_driver(::AbstractRNG, d, obs)
     throw(
         ArgumentError(
             "ACDC has no `_emission_to_driver` method for emission of type " *
             "$(typeof(d)). Supported out of the box: continuous/discrete " *
             "univariate `Distributions`, `MvNormal`, `PoissonZeroInflated`, and " *
             "`MultivariateT`/`MultivariateTDiag`. Define " *
-            "`EmissionModels._emission_to_driver(dist, obs)` returning a vector " *
-            "of drivers in [0,1] to add support.",
+            "`EmissionModels._emission_to_driver(rng, dist, obs)` returning a " *
+            "vector of drivers in [0,1] to add support.",
         ),
     )
 end

--- a/src/acdc/hmm.jl
+++ b/src/acdc/hmm.jl
@@ -6,7 +6,7 @@
    with a custom driver method). =#
 
 """
-    stochastic_drivers(hmm::AbstractHMM, obs_seq; control_seq, seq_ends, n_samples=1)
+    stochastic_drivers(hmm::AbstractHMM, obs_seq; control_seq, seq_ends, n_samples=1, rng)
 
 Recover the ACDC stochastic drivers for a fitted HiddenMarkovModels.jl `hmm`.
 
@@ -26,6 +26,8 @@ posterior expected time spent in each state.
 - `seq_ends`: end indices when `obs_seq` concatenates multiple sequences; defaults
   to `(length(obs_seq),)`.
 - `n_samples::Int=1`: number of posterior sampling passes over the data.
+- `rng::AbstractRNG=Random.default_rng()`: source of randomness for the posterior
+  state sampling and the randomized PITs — seed it for reproducible drivers.
 
 # Returns
 - [`StochasticDriverResult`](@ref) with per-state driver pools and usage.
@@ -36,8 +38,10 @@ function stochastic_drivers(
     control_seq::AbstractVector=fill(nothing, length(obs_seq)),
     seq_ends=(length(obs_seq),),
     n_samples::Int=1,
+    rng::AbstractRNG=Random.default_rng(),
 )
     n_samples > 0 || throw(ArgumentError("n_samples must be positive"))
+    isempty(obs_seq) && throw(ArgumentError("obs_seq must be non-empty"))
     T_len = length(obs_seq)
     K = length(hmm)
 
@@ -50,7 +54,7 @@ function stochastic_drivers(
     # Driver dimension from a probe on the first observation's sampled-state-able
     # emission (all states share the emission dimension in an HMM).
     probe = _emission_to_driver(
-        obs_distributions(hmm, control_seq[1])[1], obs_seq[1], control_seq[1]
+        rng, obs_distributions(hmm, control_seq[1])[1], obs_seq[1], control_seq[1]
     )
     D = length(probe)
     Tε = eltype(probe)
@@ -58,9 +62,9 @@ function stochastic_drivers(
     ε_lists = [Vector{Vector{Tε}}() for _ in 1:K]
     for _ in 1:n_samples
         for t in 1:T_len
-            z = _sample_categorical(view(γ, :, t))
+            z = _sample_categorical(rng, view(γ, :, t))
             dist = obs_distributions(hmm, control_seq[t])[z]
-            push!(ε_lists[z], _emission_to_driver(dist, obs_seq[t], control_seq[t]))
+            push!(ε_lists[z], _emission_to_driver(rng, dist, obs_seq[t], control_seq[t]))
         end
     end
 

--- a/src/acdc/interface.jl
+++ b/src/acdc/interface.jl
@@ -95,25 +95,31 @@ function stochastic_drivers(model, data; kwargs...)
 end
 
 """
-    component_discrepancies(model, data, discrepancy; n_samples=1, kwargs...) -> ACDCResult
+    component_discrepancies(model, data, discrepancy; n_samples=1, rng, kwargs...) -> ACDCResult
 
 Compute per-component discrepancies from ``U(0,1)`` for a fitted `model`.
 
 Recovers the stochastic drivers via [`stochastic_drivers`](@ref) and scores each
-component's driver pool with `discrepancy`. Extra keyword arguments are forwarded
-to `stochastic_drivers`.
+component's driver pool with `discrepancy`. The `rng` drives both the driver
+recovery and any Monte Carlo discrepancy estimates — seed it for reproducible
+results. Extra keyword arguments are forwarded to `stochastic_drivers`.
 """
 function component_discrepancies(
-    model, data, discrepancy::ComponentDiscrepancy; n_samples::Int=1, kwargs...
+    model,
+    data,
+    discrepancy::ComponentDiscrepancy;
+    n_samples::Int=1,
+    rng::AbstractRNG=Random.default_rng(),
+    kwargs...,
 )
-    result = stochastic_drivers(model, data; n_samples=n_samples, kwargs...)
+    result = stochastic_drivers(model, data; n_samples=n_samples, rng=rng, kwargs...)
     usage = result.usage
     K = length(usage)
     T = eltype(usage)
 
     discs = Vector{T}(undef, K)
     for k in 1:K
-        discs[k] = T(compute_discrepancy(discrepancy, result.ε_pools[k]))
+        discs[k] = T(compute_discrepancy(discrepancy, result.ε_pools[k]; rng=rng))
     end
 
     return ACDCResult(K, discs, usage)
@@ -220,15 +226,23 @@ end
 MMDDiscrepancy(; kwargs...) = MMDDiscrepancy{Float64}(; kwargs...)
 
 """
-    compute_discrepancy(d::ComponentDiscrepancy, samples::AbstractMatrix) -> Real
+    compute_discrepancy(d::ComponentDiscrepancy, samples::AbstractMatrix; rng) -> Real
 
 Divergence between the empirical distribution of `samples` (a `D × N` matrix of
-drivers in ``[0,1]``) and ``U([0,1]^D)``. Non-negative.
+drivers in ``[0,1]``) and ``U([0,1]^D)``. Non-negative. Samples of any `Real`
+eltype are accepted and computed at the discrepancy's precision `T`.
+
+The `rng` keyword (default `Random.default_rng()`) feeds the Monte Carlo
+estimates in [`WassersteinDiscrepancy`](@ref) (sliced projections for `D > 1`)
+and [`MMDDiscrepancy`](@ref) (uniform reference sample); the other measures are
+deterministic and ignore it.
 """
 function compute_discrepancy end
 
 function compute_discrepancy(
-    d::KLDiscrepancy{T}, samples::AbstractMatrix{T}
+    d::KLDiscrepancy{T},
+    samples::AbstractMatrix{<:Real};
+    rng::AbstractRNG=Random.default_rng(),
 ) where {T<:Real}
     D, N = size(samples)
     k = d.k_neighbors
@@ -240,7 +254,7 @@ function compute_discrepancy(
 
     # Probit transform to N(0,1) space; clamp to avoid ±Inf at the boundaries.
     ϵ = eps(T)
-    samples_clamped = clamp.(samples, ϵ, one(T) - ϵ)
+    samples_clamped = clamp.(T.(samples), ϵ, one(T) - ϵ)
     samples_normal = quantile.(Normal(zero(T), one(T)), samples_clamped)
 
     # E[log p_data] via k-NN in R^D.
@@ -255,13 +269,15 @@ function compute_discrepancy(
 end
 
 function compute_discrepancy(
-    d::KSDiscrepancy{T}, samples::AbstractMatrix{T}
+    d::KSDiscrepancy{T},
+    samples::AbstractMatrix{<:Real};
+    rng::AbstractRNG=Random.default_rng(),
 ) where {T<:Real}
     D, N = size(samples)
 
     max_ks = zero(T)
     for dim in 1:D
-        x = sort(view(samples, dim, :))
+        x = sort!(T.(view(samples, dim, :)))
         ecdf_vals = collect(T, 1:N) ./ N
         ref_cdf_vals = clamp.(x, zero(T), one(T))
         ks_stat = maximum(
@@ -276,7 +292,9 @@ function compute_discrepancy(
 end
 
 function compute_discrepancy(
-    d::SquaredErrorDiscrepancy{T}, samples::AbstractMatrix{T}
+    d::SquaredErrorDiscrepancy{T},
+    samples::AbstractMatrix{<:Real};
+    rng::AbstractRNG=Random.default_rng(),
 ) where {T<:Real}
     D, N = size(samples)
     total_err = zero(T)
@@ -295,16 +313,18 @@ function compute_discrepancy(
         end
     end
 
-    return total_err / D
+    return T(total_err / D)
 end
 
 function compute_discrepancy(
-    d::WassersteinDiscrepancy{T}, samples::AbstractMatrix{T}
+    d::WassersteinDiscrepancy{T},
+    samples::AbstractMatrix{<:Real};
+    rng::AbstractRNG=Random.default_rng(),
 ) where {T<:Real}
     D, N = size(samples)
 
     if D == 1
-        x_sorted = sort(vec(samples))
+        x_sorted = sort!(T.(vec(samples)))
         quantiles = [(i - T(0.5)) / N for i in 1:N]
         w_dist = zero(T)
         for i in 1:N
@@ -313,14 +333,15 @@ function compute_discrepancy(
         return (w_dist / N)^(one(T) / d.p)
     else
         # Sliced Wasserstein: average over random 1D projections.
+        S = T.(samples)
         n_projections = 50
         total_w = zero(T)
         for _ in 1:n_projections
-            direction = randn(T, D)
+            direction = randn(rng, T, D)
             direction ./= norm(direction)
 
-            x_sorted = sort(vec(direction' * samples))
-            ref_samples = sort(vec(direction' * rand(T, D, N)))
+            x_sorted = sort!(vec(direction' * S))
+            ref_samples = sort!(vec(direction' * rand(rng, T, D, N)))
 
             w_dist = zero(T)
             for i in 1:N
@@ -333,13 +354,16 @@ function compute_discrepancy(
 end
 
 function compute_discrepancy(
-    d::MMDDiscrepancy{T}, samples::AbstractMatrix{T}
+    d::MMDDiscrepancy{T},
+    samples::AbstractMatrix{<:Real};
+    rng::AbstractRNG=Random.default_rng(),
 ) where {T<:Real}
     D, N = size(samples)
+    S = T.(samples)
 
     if N <= d.block_size
-        reference_uniform = rand(T, D, N)
-        return _compute_mmd_quadratic_unbiased(samples, reference_uniform, d.sigma)
+        reference_uniform = rand(rng, T, D, N)
+        return _compute_mmd_quadratic_unbiased(S, reference_uniform, d.sigma)
     end
 
     # Block strategy for large N: average MMD over disjoint blocks.
@@ -348,8 +372,8 @@ function compute_discrepancy(
     for b in 1:n_blocks
         start_idx = (b - 1) * d.block_size + 1
         end_idx = b * d.block_size
-        block_samples = view(samples, :, start_idx:end_idx)
-        reference = rand(T, D, d.block_size)
+        block_samples = view(S, :, start_idx:end_idx)
+        reference = rand(rng, T, D, d.block_size)
         total_mmd += _compute_mmd_quadratic_unbiased(block_samples, reference, d.sigma)
     end
     return max(zero(T), total_mmd / n_blocks)
@@ -372,13 +396,13 @@ breaking ties toward smaller `K`. `results` must be ordered by `K`.
 """
 function acdc_select(results::Vector{ACDCResult{T}}, ρ::Real) where {T<:Real}
     losses = [acdc_loss(r, ρ) for r in results]
-    min_loss = minimum(losses)
-    for (i, loss) in enumerate(losses)
-        if loss ≈ min_loss
-            return results[i].K
-        end
+    #= `results` is ordered by K, so return the earliest entry whose loss ties
+       the minimum (`≈` absorbs float noise in the hinge sums). =#
+    best = argmin(losses)
+    for i in 1:(best - 1)
+        losses[i] ≈ losses[best] && return results[i].K
     end
-    return results[argmin(losses)].K
+    return results[best].K
 end
 
 """

--- a/test/acdc/test_acdc.jl
+++ b/test/acdc/test_acdc.jl
@@ -109,7 +109,7 @@ end
 
     # ZIP: randomized PIT drivers are ~U(0,1) under the true model.
     zip = PoissonZeroInflated(3.0, 0.25)
-    zeps = [EM._emission_to_driver(zip, rand(rng, zip))[1] for _ in 1:40_000]
+    zeps = [EM._emission_to_driver(rng, zip, rand(rng, zip))[1] for _ in 1:40_000]
     @test all(0 .<= zeps .<= 1)
     @test isapprox(Statistics.mean(zeps), 0.5; atol=0.02)
     @test isapprox(Statistics.var(zeps), 1 / 12; atol=0.01)
@@ -117,7 +117,7 @@ end
 
     Σ = [1.0 0.5 0.2; 0.5 2.0 0.3; 0.2 0.3 1.5]
     mvt = MultivariateT([1.0, -2.0, 0.5], Σ, 6.0)
-    E = reduce(hcat, (EM._emission_to_driver(mvt, rand(rng, mvt)) for _ in 1:40_000))
+    E = reduce(hcat, (EM._emission_to_driver(rng, mvt, rand(rng, mvt)) for _ in 1:40_000))
     @test size(E, 1) == 3
     @test all(0 .<= E .<= 1)
     @test all(isapprox.(vec(Statistics.mean(E; dims=2)), 0.5; atol=0.02))
@@ -127,7 +127,9 @@ end
 
     # Diagonal scale variant.
     mvtd = MultivariateTDiag([0.0, 1.0], [1.0, 3.0], 4.0)
-    Ed = reduce(hcat, (EM._emission_to_driver(mvtd, rand(rng, mvtd)) for _ in 1:40_000))
+    Ed = reduce(
+        hcat, (EM._emission_to_driver(rng, mvtd, rand(rng, mvtd)) for _ in 1:40_000)
+    )
     @test all(0 .<= Ed .<= 1)
     @test compute_discrepancy(KSDiscrepancy(), Ed) < 0.05
     @test abs(Statistics.cov(Ed[1, :], Ed[2, :])) < 0.01
@@ -148,7 +150,7 @@ end
         e = Float64[]
         for _ in 1:N
             x = mkx()
-            push!(e, EM._emission_to_driver(g, rand(rng, g; control_seq=x), x)[1])
+            push!(e, EM._emission_to_driver(rng, g, rand(rng, g; control_seq=x), x)[1])
         end
         @test all(0 .<= e .<= 1)
         @test isapprox(Statistics.mean(e), 0.5; atol=0.02)
@@ -160,7 +162,7 @@ end
     Eg = Matrix{Float64}(undef, 2, N)
     for i in 1:N
         x = mkx()
-        Eg[:, i] = EM._emission_to_driver(mg, rand(rng, mg; control_seq=x), x)
+        Eg[:, i] = EM._emission_to_driver(rng, mg, rand(rng, mg; control_seq=x), x)
     end
     @test compute_discrepancy(KSDiscrepancy(), Eg) < 0.05
     @test abs(Statistics.cov(Eg[1, :], Eg[2, :])) < 0.01
@@ -172,15 +174,15 @@ end
         E = Matrix{Float64}(undef, 2, N)
         for i in 1:N
             x = mkx()
-            E[:, i] = EM._emission_to_driver(g, rand(rng, g; control_seq=x), x)
+            E[:, i] = EM._emission_to_driver(rng, g, rand(rng, g; control_seq=x), x)
         end
         @test all(0 .<= E .<= 1)
         @test compute_discrepancy(KSDiscrepancy(), E) < 0.05
         @test abs(Statistics.cov(E[1, :], E[2, :])) < 0.01
     end
 
-    # 2-arg form on a GLM ⇒ clear error (covariate required).
-    @test_throws ArgumentError EM._emission_to_driver(GaussianGLM([0.5], 1.0), 1.0)
+    # Covariate-free form on a GLM ⇒ clear error (covariate required).
+    @test_throws ArgumentError EM._emission_to_driver(rng, GaussianGLM([0.5], 1.0), 1.0)
 end
 
 @testset "Discrepancy edge cases" begin
@@ -202,7 +204,7 @@ end
         Float32
 
     # Unsupported emission ⇒ clear error.
-    @test_throws ArgumentError EmissionModels._emission_to_driver(missing, 1.0)
+    @test_throws ArgumentError EmissionModels._emission_to_driver(rng, missing, 1.0)
 
     # Unsupported model ⇒ stochastic_drivers fallback errors (also via the
     # component_discrepancies path, which forwards to stochastic_drivers).
@@ -216,8 +218,49 @@ end
     _, obs_seq = rand(rng, hmm, 100)
 
     @test_throws ArgumentError stochastic_drivers(hmm, obs_seq; n_samples=0)
+    @test_throws ArgumentError stochastic_drivers(hmm, eltype(obs_seq)[])
 
     # n_samples > 1 multiplies the pool size (one assignment per step per pass).
     sd = stochastic_drivers(hmm, obs_seq; n_samples=2)
     @test sum(size.(sd.ε_pools, 2)) == 200
+end
+
+@testset "Reproducibility with a seeded rng" begin
+    rng = Random.MersenneTwister(31)
+    hmm = HMM([0.5, 0.5], [0.9 0.1; 0.1 0.9], [Poisson(2.0), Poisson(15.0)])
+    _, obs_seq = rand(rng, hmm, 500)
+
+    # Same seed ⇒ identical drivers and identical discrepancies.
+    sd1 = stochastic_drivers(hmm, obs_seq; rng=Random.MersenneTwister(7))
+    sd2 = stochastic_drivers(hmm, obs_seq; rng=Random.MersenneTwister(7))
+    @test sd1.ε_pools == sd2.ε_pools
+    @test sd1.usage == sd2.usage
+
+    r1 = component_discrepancies(
+        hmm, obs_seq, KSDiscrepancy(); rng=Random.MersenneTwister(7)
+    )
+    r2 = component_discrepancies(
+        hmm, obs_seq, KSDiscrepancy(); rng=Random.MersenneTwister(7)
+    )
+    @test r1.component_discrepancies == r2.component_discrepancies
+
+    # Monte Carlo discrepancies are reproducible under a seeded rng too.
+    U = rand(Random.MersenneTwister(1), 2, 500)
+    w1 = compute_discrepancy(WassersteinDiscrepancy(), U; rng=Random.MersenneTwister(3))
+    w2 = compute_discrepancy(WassersteinDiscrepancy(), U; rng=Random.MersenneTwister(3))
+    @test w1 == w2
+    m1 = compute_discrepancy(MMDDiscrepancy(), U; rng=Random.MersenneTwister(3))
+    m2 = compute_discrepancy(MMDDiscrepancy(), U; rng=Random.MersenneTwister(3))
+    @test m1 == m2
+end
+
+@testset "Discrepancies accept any Real eltype" begin
+    rng = Random.MersenneTwister(6)
+    U32 = rand(rng, Float32, 2, 500)
+    # Default (Float64) discrepancies on Float32 pools compute at Float64.
+    @test compute_discrepancy(KSDiscrepancy(), U32) isa Float64
+    @test compute_discrepancy(KLDiscrepancy(), U32) isa Float64
+    @test compute_discrepancy(SquaredErrorDiscrepancy(), U32) isa Float64
+    @test compute_discrepancy(WassersteinDiscrepancy(), U32) isa Float64
+    @test compute_discrepancy(MMDDiscrepancy(), U32) isa Float64
 end


### PR DESCRIPTION
- `stochastic_drivers`, `component_discrepancies`, and `compute_discrepancy` take an `rng` kwarg; the randomized PITs, posterior state sampling, sliced-Wasserstein projections, and MMD reference all used the global RNG, so results weren't reproducible. `_emission_to_driver` now takes `rng` as its first argument (docs updated).
- Discrepancies accept any `Real` eltype instead of erroring on e.g. Float32 pools.
- `stochastic_drivers` throws a clear error on empty `obs_seq` instead of a `BoundsError`.
- Removed unreachable fallback in `acdc_select`.