### PR TITLE
Performance: allocation-free ν step, t-dist rand!, symmetric-triangle accumulation

### DIFF
--- a/src/EmissionModels.jl
+++ b/src/EmissionModels.jl
@@ -13,7 +13,7 @@ using NearestNeighbors: KDTree, knn
 using Optim: Optim, optimize, TwiceDifferentiable, Newton
 using Optim.NLSolversBase: only_fgh!
 using Random
-using SpecialFunctions: logfactorial, loggamma, digamma, trigamma, polygamma
+using SpecialFunctions: logfactorial, loggamma, digamma, trigamma
 using Statistics: mean, var, cov
 using StatsAPI
 using StatsAPI: fit!

--- a/src/glms/glm.jl
+++ b/src/glms/glm.jl
@@ -152,6 +152,9 @@ function StatsAPI.fit!(
     XWy = zeros(T, p)
     wsum = zero(T)
 
+    #= XᵀWX is symmetric: accumulate only the lower triangle (stride-1 in the
+       first index), halving the inner-loop work; the Cholesky below reads
+       uplo = :L. =#
     for i in 1:n
         w = T(weights[i])
         wsum += w
@@ -160,8 +163,8 @@ function StatsAPI.fit!(
         for a in 1:p
             xa = x_i[a]
             wxa = w * xa
-            for b in 1:p
-                XWX[a, b] += wxa * x_i[b]
+            for b in a:p
+                XWX[b, a] += wxa * x_i[b]
             end
             XWy[a] += wxa * y_i
         end
@@ -170,7 +173,7 @@ function StatsAPI.fit!(
     # RidgePrior(λ) accumulates λI into XᵀWX, giving (XᵀWX + λI)β = XᵀWy.
     neglogprior_hess!(reg.prior, XWX, reg.β)
 
-    F = cholesky!(Symmetric(XWX); check=false)
+    F = cholesky!(Symmetric(XWX, :L); check=false)
     issuccess(F) || throw(
         ArgumentError(
             "XᵀWX is not positive definite — `control_seq` is rank-deficient " *
@@ -246,11 +249,19 @@ function (o::_BernoulliFGH)(F, G, H, β::AbstractVector{T}) where {T<:Real}
                 G === nothing || (G[a] += r_i * xa)
                 if H !== nothing
                     wxa = W_i * xa
-                    for b in 1:p
-                        H[a, b] += wxa * x_i[b]
+                    # Symmetric H: accumulate the lower triangle only,
+                    # mirrored after the data pass.
+                    for b in a:p
+                        H[b, a] += wxa * x_i[b]
                     end
                 end
             end
+        end
+    end
+    if H !== nothing
+        # Optim's Newton reads the full matrix — mirror the lower triangle.
+        for a in 1:p, b in (a + 1):p
+            H[a, b] = H[b, a]
         end
     end
     G === nothing || neglogprior_grad!(o.prior, G, β)
@@ -299,11 +310,19 @@ function (o::_PoissonFGH)(F, G, H, β::AbstractVector{T}) where {T<:Real}
                 G === nothing || (G[a] += r_i * xa)
                 if H !== nothing
                     wxa = W_i * xa
-                    for b in 1:p
-                        H[a, b] += wxa * x_i[b]
+                    # Symmetric H: accumulate the lower triangle only,
+                    # mirrored after the data pass.
+                    for b in a:p
+                        H[b, a] += wxa * x_i[b]
                     end
                 end
             end
+        end
+    end
+    if H !== nothing
+        # Optim's Newton reads the full matrix — mirror the lower triangle.
+        for a in 1:p, b in (a + 1):p
+            H[a, b] = H[b, a]
         end
     end
     G === nothing || neglogprior_grad!(o.prior, G, β)
@@ -373,6 +392,11 @@ P(Y=1|x) = σ(xᵀβ) where σ is the logistic function. `fit!` minimizes the
 weighted negative log-posterior via Optim's Newton method with analytic
 gradient and Hessian, so any `AbstractPrior` composes without changes to
 the solver.
+
+!!! note
+    If the data are linearly separable, the unpenalized MLE does not exist —
+    ‖β‖ diverges and the Hessian becomes singular. Use a `RidgePrior(λ)` to
+    keep the fit finite in that regime.
 
 # Fields
 - `β`: coefficient vector (length p)
@@ -713,7 +737,9 @@ function StatsAPI.fit!(
     XWY = zeros(T, p, k)
     wsum = zero(T)
 
-    # Build XᵀWX and XᵀWY in a single pass — no Y matrix, no temporaries.
+    #= Build XᵀWX and XᵀWY in a single pass — no Y matrix, no temporaries.
+       XᵀWX is symmetric: only the lower triangle is accumulated (stride-1 in
+       the first index); the Cholesky below reads uplo = :L. =#
     for i in 1:n
         obs_i = obs_seq[i]
         length(obs_i) == k ||
@@ -724,8 +750,8 @@ function StatsAPI.fit!(
         for a in 1:p
             xa = x_i[a]
             wxa = w * xa
-            for b in 1:p
-                XWX[a, b] += wxa * x_i[b]
+            for b in a:p
+                XWX[b, a] += wxa * x_i[b]
             end
             for j in 1:k
                 XWY[a, j] += wxa * T(obs_i[j])

--- a/src/multivariate/t.jl
+++ b/src/multivariate/t.jl
@@ -193,10 +193,29 @@ Generate a random sample from the multivariate t-distribution.
 Uses the representation: X = μ + √(ν/U) × Z
 where Z ~ N(0, Σ) and U ~ χ²(ν) are independent.
 """
-function Random.rand(rng::AbstractRNG, dist::MultivariateT)
+function Random.rand(rng::AbstractRNG, dist::MultivariateT{T}) where {T<:Real}
+    return rand!(rng, dist, Vector{T}(undef, dist.dim))
+end
+
+"""
+    rand!(rng, dist::MultivariateT, out)
+
+In-place sample into `out` (length `dim`). Zero allocation, thread-safe: draw
+`z ~ N(0, I)` directly into `out`, multiply by the Cholesky factor in place
+(`lmul!`), then scale by √(ν/u) and shift by μ element-wise.
+"""
+function Random.rand!(rng::AbstractRNG, dist::MultivariateT, out::AbstractVector)
+    length(out) == dist.dim ||
+        throw(DimensionMismatch("out length $(length(out)) ≠ dim $(dist.dim)"))
+
     u = rand(rng, Chisq(dist.ν))
-    z = randn(rng, dist.dim)
-    return dist.μ .+ sqrt(dist.ν / u) .* (dist.Σ_chol.L * z)
+    s = sqrt(dist.ν / u)
+    randn!(rng, out)
+    lmul!(dist.Σ_chol.L, out)        # out = L * z, in place
+    for i in 1:(dist.dim)
+        out[i] = dist.μ[i] + s * out[i]
+    end
+    return out
 end
 
 """
@@ -204,10 +223,26 @@ end
 
 Generate a random sample from the diagonal multivariate t-distribution.
 """
-function Random.rand(rng::AbstractRNG, dist::MultivariateTDiag)
+function Random.rand(rng::AbstractRNG, dist::MultivariateTDiag{T}) where {T<:Real}
+    return rand!(rng, dist, Vector{T}(undef, dist.dim))
+end
+
+"""
+    rand!(rng, dist::MultivariateTDiag, out)
+
+In-place sample into `out` (length `dim`). Zero allocation, thread-safe.
+"""
+function Random.rand!(rng::AbstractRNG, dist::MultivariateTDiag, out::AbstractVector)
+    length(out) == dist.dim ||
+        throw(DimensionMismatch("out length $(length(out)) ≠ dim $(dist.dim)"))
+
     u = rand(rng, Chisq(dist.ν))
-    z = randn(rng, dist.dim)
-    return dist.μ .+ sqrt(dist.ν / u) .* sqrt.(dist.σ²) .* z
+    s = sqrt(dist.ν / u)
+    randn!(rng, out)
+    for i in 1:(dist.dim)
+        out[i] = dist.μ[i] + s * sqrt(dist.σ²[i]) * out[i]
+    end
+    return out
 end
 
 #= Array forms (`rand(dist, n)` etc.) go through Random's sampler machinery,
@@ -222,67 +257,49 @@ function Random.rand(
 end
 
 #= ECME degrees-of-freedom update, shared by the `MultivariateT` and
-   `MultivariateTDiag` fits. The t-distribution ν M-step minimises f(ν)² over
-   x = log ν (log-space keeps ν > 0), where the stationarity condition is
+   `MultivariateTDiag` fits. The ν M-step solves the stationarity condition
 
-       f(ν) = -ψ(ν/2) + log(ν/2) + 1 + C + ψ((ν+d)/2) - log((ν+d)/2),
+       f(ν) = -ψ(ν/2) + log(ν/2) + 1 + C + ψ((ν+d)/2) - log((ν+d)/2) = 0,
 
-   and C = Σᵢ w̃ᵢ (log uᵢ - uᵢ) is the supplied `avg_log_u_minus_u` (uᵢ are the
-   per-observation posterior weights). Solved with Optim's Newton using the
-   analytic gradient and Hessian.
-
-   The objective/gradient/Hessian are top-level callable structs (functors)
-   parameterised by `(C, d)`, not closures defined inside `_update_nu`: their
-   method bodies compile once, so each ν M-step only instantiates three tiny
-   immutable structs instead of rebuilding closures on every call. `_nu_f` /
-   `_nu_df` / `_nu_d2f` hold the single definition of the residual and its
-   ν-derivatives, shared by all three functors. =#
+   where C = Σᵢ w̃ᵢ (log uᵢ - uᵢ) is the supplied `avg_log_u_minus_u` (uᵢ are the
+   per-observation posterior weights). f decreases from +∞ (ν → 0) to 1 + C ≤ 0
+   (ν → ∞; log u - u ≤ -1 by Jensen), so a bracketed Newton on x = log ν with
+   bisection fallback always converges. This runs once per EM iteration, so it
+   is solved inline rather than through Optim: zero allocations, and the
+   bracket doubles as a hard cap — near-Gaussian data (C → -1) pushes the root
+   toward ν = ∞, and the cap returns a large-but-finite ν instead of letting
+   exp(x) overflow into the next E-step. =#
 function _nu_f(ν, C, d)
     return -digamma(ν / 2) + log(ν / 2) + 1 + C + digamma((ν + d) / 2) - log((ν + d) / 2)
 end
 _nu_df(ν, d) = -0.5 * trigamma(ν / 2) + 1 / ν + 0.5 * trigamma((ν + d) / 2) - 1 / (ν + d)
-function _nu_d2f(ν, d)
-    return -0.25 * polygamma(2, ν / 2) - 1 / ν^2 +
-           0.25 * polygamma(2, (ν + d) / 2) +
-           1 / (ν + d)^2
-end
-
-struct _NuObjective{T}
-    C::T
-    d::Int
-end
-(o::_NuObjective)(x::Vector) = _nu_f(exp(x[1]), o.C, o.d)^2
-
-struct _NuGradient{T}
-    C::T
-    d::Int
-end
-function (g::_NuGradient)(G, x::Vector)
-    ν = exp(x[1])
-    G[1] = 2 * _nu_f(ν, g.C, g.d) * _nu_df(ν, g.d) * ν
-    return G
-end
-
-struct _NuHessian{T}
-    C::T
-    d::Int
-end
-function (h::_NuHessian)(H, x::Vector)
-    ν = exp(x[1])
-    f = _nu_f(ν, h.C, h.d)
-    df = _nu_df(ν, h.d)
-    d2f = _nu_d2f(ν, h.d)
-    H[1, 1] = (2 * df^2 + 2 * f * d2f) * ν^2 + 2 * f * df * ν
-    return H
-end
 
 function _update_nu(ν0::Real, avg_log_u_minus_u, d::Integer)
     C = avg_log_u_minus_u
-    td = TwiceDifferentiable(
-        _NuObjective(C, d), _NuGradient(C, d), _NuHessian(C, d), [log(ν0)]
-    )
-    result = optimize(td, [log(ν0)], Newton())
-    return exp(Optim.minimizer(result)[1])
+    T = float(promote_type(typeof(ν0), typeof(C)))
+    ν_lo, ν_hi = T(1e-2), T(1e6)
+    _nu_f(ν_lo, C, d) <= 0 && return ν_lo
+    _nu_f(ν_hi, C, d) >= 0 && return ν_hi
+
+    lo, hi = log(ν_lo), log(ν_hi)
+    x = clamp(log(T(ν0)), lo, hi)
+    tol = sqrt(eps(T))
+    for _ in 1:100
+        ν = exp(x)
+        fx = _nu_f(ν, C, d)
+        abs(fx) < tol && break
+        # Maintain the sign-change bracket (f decreasing: f(lo) > 0 > f(hi)).
+        if fx > 0
+            lo = x
+        else
+            hi = x
+        end
+        # Newton step in log-space; bisect whenever it leaves the bracket.
+        x_new = x - fx / (_nu_df(ν, d) * ν)
+        x = lo < x_new < hi ? x_new : (lo + hi) / 2
+        hi - lo < tol && break
+    end
+    return exp(x)
 end
 
 #= 

--- a/src/zeroinflated/poisson.jl
+++ b/src/zeroinflated/poisson.jl
@@ -119,8 +119,7 @@ function StatsAPI.fit!(
     end
 
     epsilon = eps(typeof(dist.λ))
-    zero_mask = obs_seq .== 0
-    if sum(zero_mask) == length(obs_seq)
+    if all(iszero, obs_seq)
         dist.π = 1.0 - epsilon
         dist.λ = epsilon
         return dist

--- a/test/allocations.jl
+++ b/test/allocations.jl
@@ -66,6 +66,12 @@ for _ in 1:n
     s += rand(rng, d)[1]
 end;
 s)
+bench_rand!_unctrl(rng, d, out, n) = (s = 0.0;
+for _ in 1:n
+    rand!(rng, d, out)
+    s += out[1]
+end;
+s)
 
 @testset "Allocations (steady state)" begin
     rng = Random.MersenneTwister(0)
@@ -199,7 +205,8 @@ s)
         zip2 = PoissonZeroInflated(1.0, 0.1)
         fit!(zip2, y, w)
         zip2 = PoissonZeroInflated(1.0, 0.1)
-        @test (@allocated fit!(zip2, y, w)) ≤ 8_000
+        # No n-length mask anymore (all(iszero, ...)) — accumulators only.
+        @test (@allocated fit!(zip2, y, w)) ≤ 1_000
     end
 
     @testset "MultivariateT (full Σ)" begin
@@ -212,9 +219,14 @@ s)
         bench_logd_unctrl(mvt, xv, 1)
         @test (@allocated bench_logd_unctrl(mvt, xv, REPS)) ≤ 256 * REPS
 
+        # rand! into a pre-allocated buffer — zero alloc.
+        out = zeros(d)
+        bench_rand!_unctrl(rng, mvt, out, 1)
+        @test (@allocated bench_rand!_unctrl(rng, mvt, out, REPS)) <= ALLOC_SLOP
+
+        # rand allocates only the returned vector.
         bench_rand_unctrl_vec(rng, mvt, 1)
-        # rand still allocates the return vector; bound it loosely.
-        @test (@allocated bench_rand_unctrl_vec(rng, mvt, REPS)) ≤ 600 * REPS
+        @test (@allocated bench_rand_unctrl_vec(rng, mvt, REPS)) ≤ 256 * REPS
 
         n = 500
         obs = [randn(rng, d) for _ in 1:n]
@@ -222,8 +234,9 @@ s)
         mvt2 = MultivariateT([0.0, 0.0], Matrix(1.0I, d, d), 5.0)
         fit!(mvt2, obs, w; max_iter=5)
         mvt2 = MultivariateT([0.0, 0.0], Matrix(1.0I, d, d), 5.0)
-        # ν step still goes through Optim — loose bound.
-        @test (@allocated fit!(mvt2, obs, w; max_iter=5)) ≤ 1_000_000
+        # Per-call workspace (posterior weights, μ/scale buffers, Cholesky);
+        # the ν step is an inline allocation-free Newton. Measured ~5 KB.
+        @test (@allocated fit!(mvt2, obs, w; max_iter=5)) ≤ 20_000
     end
 
     @testset "MultivariateTDiag" begin
@@ -234,8 +247,12 @@ s)
         bench_logd_unctrl(mvtd, xv, 1)
         @test (@allocated bench_logd_unctrl(mvtd, xv, REPS)) <= ALLOC_SLOP
 
+        out = zeros(d)
+        bench_rand!_unctrl(rng, mvtd, out, 1)
+        @test (@allocated bench_rand!_unctrl(rng, mvtd, out, REPS)) <= ALLOC_SLOP
+
         bench_rand_unctrl_vec(rng, mvtd, 1)
-        @test (@allocated bench_rand_unctrl_vec(rng, mvtd, REPS)) ≤ 400 * REPS
+        @test (@allocated bench_rand_unctrl_vec(rng, mvtd, REPS)) ≤ 256 * REPS
 
         n = 500
         obs = [randn(rng, d) for _ in 1:n]
@@ -243,6 +260,6 @@ s)
         mvtd2 = MultivariateTDiag([0.0, 0.0], [1.0, 1.0], 5.0)
         fit!(mvtd2, obs, w; max_iter=5)
         mvtd2 = MultivariateTDiag([0.0, 0.0], [1.0, 1.0], 5.0)
-        @test (@allocated fit!(mvtd2, obs, w; max_iter=5)) ≤ 500_000
+        @test (@allocated fit!(mvtd2, obs, w; max_iter=5)) ≤ 20_000
     end
 end

--- a/test/multivariate/test_t.jl
+++ b/test/multivariate/test_t.jl
@@ -592,3 +592,33 @@ end
     distd = MultivariateTDiag(Float32[0, 0], Float32[1, 1], 5.0f0)
     @test logdensityof(distd, Float32[0.1, 0.2]) isa Float32
 end
+
+@testset "ν M-step stays finite on near-Gaussian data" begin
+    # Gaussian observations push the ECME ν update toward ∞; the bracketed
+    # solver must return a finite (capped) ν instead of overflowing.
+    rng = Random.MersenneTwister(202)
+    obs = [randn(rng, 2) for _ in 1:2000]
+    w = ones(2000)
+    dist = MultivariateT([0.0, 0.0], [1.0 0.0; 0.0 1.0], 5.0)
+    fit!(dist, obs, w; max_iter=100)
+    @test isfinite(dist.ν)
+    @test dist.ν <= 1.0e6
+    @test all(isfinite, dist.μ)
+    @test all(isfinite, dist.Σ)
+end
+
+@testset "rand! in-place sampling" begin
+    rng = Random.MersenneTwister(303)
+    dist = MultivariateT([2.0, -1.0], [2.0 0.8; 0.8 1.5], 10.0)
+    out = zeros(2)
+    @test rand!(rng, dist, out) === out
+    @test_throws DimensionMismatch rand!(rng, dist, zeros(3))
+    S = reduce(hcat, (copy(rand!(rng, dist, out)) for _ in 1:20_000))
+    @test vec(mean(S; dims=2)) ≈ dist.μ atol = 0.1
+
+    distd = MultivariateTDiag([1.0, -2.0], [1.0, 2.0], 8.0)
+    @test rand!(rng, distd, out) === out
+    @test_throws DimensionMismatch rand!(rng, distd, zeros(3))
+    Sd = reduce(hcat, (copy(rand!(rng, distd, out)) for _ in 1:20_000))
+    @test vec(mean(Sd; dims=2)) ≈ distd.μ atol = 0.1
+end


### PR DESCRIPTION
- The ECME ν M-step is now an inline bracketed Newton (root of the stationarity condition) instead of an Optim solve: zero allocations per EM iteration, and the bracket caps ν at 1e6 so near-Gaussian data can't overflow. `MultivariateT` `fit!` drops from ~1 MB to ~5 KB per call; allocation test bounds tightened from 1 MB / 500 KB to 20 KB.
- `rand!(rng, dist, out)` for `MultivariateT`/`MultivariateTDiag` — zero-alloc, matching `MvGaussianGLM`; `rand` now allocates only the returned vector.
- XᵀWX / Newton Hessians accumulate only the lower triangle (halves the inner-loop work, stride-1 access).
- ZIP `fit!` no longer allocates an n-length zero mask.
- Docs note: separable data needs a `RidgePrior` for `BernoulliGLM`.

May need a trivial rebase after #36 (adjacent edits in t.jl).