### PR TITLE
Multinomial glm

### DIFF
--- a/docs/src/glm.md
+++ b/docs/src/glm.md
@@ -50,7 +50,14 @@ Multinomial logistic regression for count vectors over ``K`` categories e.g., pe
 
 ``Y \mid x \sim \text{Multinomial}(n, \ p(x))``
 
-`logdensityof` and `fit!` condition on each observation's own total count, so totals may vary across time steps; `rand` draws `n_trials` trials.
+`logdensityof` and `fit!` condition on each observation's own total count, so totals may vary across time steps; `rand` draws `n_trials` trials. For single-trial choice data they also accept plain integer labels ``y ∈ 1:K`` (treated as one-hot count vectors), so a choice sequence can stay a `Vector{Int}`:
+
+```julia
+glm = MultinomialGLM(zeros(3, 2), 1)
+choices = [1, 3, 2, 1, 3]              # e.g. left / right / no-choice labels
+fit!(glm, choices, ones(5); control_seq=X)
+logdensityof(glm, 3; control_seq=x)    # log p₃(x)
+```
 
 ```julia
 glm = MultinomialGLM(zeros(3, 2), 5)   # p = 3 inputs, K = 3 categories, 5 trials

--- a/docs/src/glm.md
+++ b/docs/src/glm.md
@@ -42,6 +42,22 @@ Log-linear regression for count observations ``Y ∈ \{0, 1, \ldots\}``.
 glm = PoissonGLM(zeros(3))
 ```
 
+### `MultinomialGLM(B, n_trials)`
+
+Multinomial logistic regression for count vectors over ``K`` categories e.g., per-time-bin choice counts including a "no choice" category. Category ``K`` is the reference; coefficients are a ``p × (K-1)`` matrix ``B``.
+
+``p_j(x) = \frac{\exp(η_j)}{\sum_{l=1}^{K} \exp(η_l)}, \quad η_j = B[:,j]ᵀx \ (j < K), \quad η_K = 0``  (softmax link)
+
+``Y \mid x \sim \text{Multinomial}(n, \ p(x))``
+
+`logdensityof` and `fit!` condition on each observation's own total count, so totals may vary across time steps; `rand` draws `n_trials` trials.
+
+```julia
+glm = MultinomialGLM(zeros(3, 2), 5)   # p = 3 inputs, K = 3 categories, 5 trials
+# or with a prior:
+glm = MultinomialGLM(zeros(3, 2), 5, RidgePrior(0.5))
+```
+
 ## Multivariate GLM types
 
 Each univariate GLM has a multivariate counterpart that emits a length-``k`` observation vector for a single input ``x``. Coefficients are stored as a ``p × k`` matrix ``B``; column ``j`` is the coefficient vector for output dimension ``j``.
@@ -86,15 +102,18 @@ EmissionModels.AbstractGLM
 GaussianGLM
 BernoulliGLM
 PoissonGLM
+MultinomialGLM
 MvGaussianGLM
 MvBernoulliGLM
 MvPoissonGLM
 DensityInterface.logdensityof(::MvGaussianGLM, ::AbstractVector)
 StatsAPI.fit!(::BernoulliGLM, ::AbstractVector, ::AbstractVector{<:Real})
 StatsAPI.fit!(::PoissonGLM, ::AbstractVector, ::AbstractVector{<:Real})
+StatsAPI.fit!(::MultinomialGLM{T}, ::AbstractVector{<:AbstractVector}, ::AbstractVector{<:Real}) where {T<:Real}
 StatsAPI.fit!(::MvGaussianGLM{T}, ::AbstractVector{<:AbstractVector}, ::AbstractVector{<:Real}) where {T<:Real}
 StatsAPI.fit!(::MvBernoulliGLM{T}, ::AbstractVector{<:AbstractVector}, ::AbstractVector{<:Real}) where {T<:Real}
 StatsAPI.fit!(::MvPoissonGLM{T}, ::AbstractVector{<:AbstractVector}, ::AbstractVector{<:Real}) where {T<:Real}
+Random.rand!(::Random.AbstractRNG, ::MultinomialGLM, ::AbstractVector)
 Random.rand!(::Random.AbstractRNG, ::MvGaussianGLM{T}, ::AbstractVector) where {T<:Real}
 Random.rand!(::Random.AbstractRNG, ::MvBernoulliGLM, ::AbstractVector)
 Random.rand!(::Random.AbstractRNG, ::MvPoissonGLM, ::AbstractVector)

--- a/src/EmissionModels.jl
+++ b/src/EmissionModels.jl
@@ -1,6 +1,6 @@
 module EmissionModels
 
-using Distributions: Normal, Bernoulli, Poisson, Chisq, TDist, MvNormal
+using Distributions: Normal, Bernoulli, Binomial, Poisson, Chisq, TDist, MvNormal
 using Distributions: cdf, quantile
 using Distributions:
     ContinuousUnivariateDistribution, DiscreteUnivariateDistribution, AbstractMvNormal
@@ -29,7 +29,7 @@ include("acdc/hmm.jl")
 export rand, logdensityof, fit!
 export PoissonZeroInflated
 export MultivariateT, MultivariateTDiag
-export GaussianGLM, BernoulliGLM, PoissonGLM
+export GaussianGLM, BernoulliGLM, PoissonGLM, MultinomialGLM
 export MvGaussianGLM, MvBernoulliGLM, MvPoissonGLM
 export AbstractPrior, NoPrior, RidgePrior
 export neglogprior, neglogprior_grad!, neglogprior_hess!

--- a/src/acdc/drivers.jl
+++ b/src/acdc/drivers.jl
@@ -153,6 +153,49 @@ function _emission_to_driver(rng::AbstractRNG, g::MvPoissonGLM, obs::AbstractVec
     return [_emission_to_driver(rng, Poisson(exp(η[j])), obs[j])[1] for j in eachindex(η)]
 end
 
+#= MultinomialGLM: the count coordinates are dependent through the shared total,
+   so stacked per-coordinate PITs are wrong. Use the discrete Rosenblatt
+   transform through the sequential conditional binomials
+       y_j | y_1..y_{j-1} ~ Binomial(n − Σ_{i<j} yᵢ, p_j / (1 − Σ_{i<j} pᵢ)),
+   applying the randomized PIT to each conditional (mirrors the sampler in
+   `rand!`). The K-th coordinate is determined by the total, so its conditional
+   is degenerate and carries no information: the driver has K−1 dimensions. =#
+function _emission_to_driver(rng::AbstractRNG, g::MultinomialGLM, obs::AbstractVector, x)
+    K = g.out_dim
+    T = float(promote_type(eltype(g.B), eltype(x)))
+
+    lse = zero(T)   # log Σₗ exp(ηₗ), reference category contributes exp(0)
+    for j in 1:(K - 1)
+        η = zero(T)
+        for r in 1:(g.in_dim)
+            η += g.B[r, j] * x[r]
+        end
+        lse = logaddexp(lse, η)
+    end
+
+    n_rem = 0
+    for yj in obs
+        n_rem += Int(yj)
+    end
+
+    ε = Vector{T}(undef, K - 1)
+    p_rem = one(T)
+    for j in 1:(K - 1)
+        η = zero(T)
+        for r in 1:(g.in_dim)
+            η += g.B[r, j] * x[r]
+        end
+        pj = exp(η - lse)
+        # p_rem can undershoot 0 by rounding once most mass is spent.
+        pc = p_rem > 0 ? clamp(pj / p_rem, zero(T), one(T)) : one(T)
+        yj = Int(obs[j])
+        ε[j] = _emission_to_driver(rng, Binomial(n_rem, Float64(pc)), yj)[1]
+        n_rem -= yj
+        p_rem -= pj
+    end
+    return ε
+end
+
 # 3-arg form on a GLM: no covariate to condition on, so point at the 4-arg hook.
 function _emission_to_driver(::AbstractRNG, g::AbstractGLM, obs)
     throw(

--- a/src/acdc/drivers.jl
+++ b/src/acdc/drivers.jl
@@ -196,6 +196,11 @@ function _emission_to_driver(rng::AbstractRNG, g::MultinomialGLM, obs::AbstractV
     return ε
 end
 
+# Label form: a single-trial choice y ∈ 1:K is its one-hot count vector.
+function _emission_to_driver(rng::AbstractRNG, g::MultinomialGLM, obs::Real, x)
+    return _emission_to_driver(rng, g, _OneHot(Int(obs), g.out_dim), x)
+end
+
 # 3-arg form on a GLM: no covariate to condition on, so point at the 4-arg hook.
 function _emission_to_driver(::AbstractRNG, g::AbstractGLM, obs)
     throw(

--- a/src/glms/glm.jl
+++ b/src/glms/glm.jl
@@ -1136,6 +1136,329 @@ function StatsAPI.fit!(
     return glm
 end
 
+#= Fused multinomial-logistic negative log-posterior, same `fgh!(F, G, H, β)`
+   contract as `_BernoulliFGH`. Categories 1..k are the non-reference ones
+   (η_K = 0); β is the flattened p×k coefficient matrix in column-major order,
+   so β[(j-1)p + a] = B[a, j]. `prob` is an owned length-k workspace reused
+   across calls: it first holds the linear predictors η_j of the current
+   observation, then is overwritten in place with the softmax probabilities. =#
+struct _MultinomialFGH{
+    Y<:AbstractVector,
+    W<:AbstractVector{<:Real},
+    M<:AbstractMatrix{<:Real},
+    P<:AbstractPrior,
+    T<:Real,
+}
+    y::Y
+    w::W
+    X::M
+    prior::P
+    k::Int
+    prob::Vector{T}
+end
+
+function (o::_MultinomialFGH)(F, G, H, β::AbstractVector{T}) where {T<:Real}
+    n, p = size(o.X)
+    k = o.k
+    G === nothing || fill!(G, zero(T))
+    H === nothing || fill!(H, zero(T))
+    nll = zero(T)
+    prob = o.prob
+    for i in 1:n
+        x_i = view(o.X, i, :)
+        wi = T(o.w[i])
+        y_i = o.y[i]
+
+        #= η_j for each non-reference category, with the running log-sum-exp
+           over (η_1, …, η_k, 0) — `lse` starts at 0 for the reference. =#
+        lse = zero(T)
+        ydotη = zero(T)
+        for j in 1:k
+            off = (j - 1) * p
+            η = zero(T)
+            for a in 1:p
+                η += β[off + a] * x_i[a]
+            end
+            prob[j] = η
+            lse = logaddexp(lse, η)
+            ydotη += T(y_i[j]) * η
+        end
+        n_i = zero(T)
+        for j in 1:(k + 1)
+            n_i += T(y_i[j])
+        end
+
+        if F !== nothing
+            nll += wi * (n_i * lse - ydotη)
+        end
+        if G !== nothing || H !== nothing
+            for j in 1:k
+                prob[j] = exp(prob[j] - lse)
+            end
+            if G !== nothing
+                for j in 1:k
+                    r_j = wi * (n_i * prob[j] - T(y_i[j]))
+                    off = (j - 1) * p
+                    for a in 1:p
+                        G[off + a] += r_j * x_i[a]
+                    end
+                end
+            end
+            if H !== nothing
+                #= Block (j,l) of the Hessian is wᵢnᵢ pⱼ(δⱼₗ − pₗ) xxᵀ.
+                   Accumulate the lower triangle of the flattened matrix only;
+                   mirrored after the data pass. =#
+                for l in 1:k
+                    pl = prob[l]
+                    c_ll = wi * n_i * pl * (one(T) - pl)
+                    for b in 1:p
+                        col = (l - 1) * p + b
+                        xb = x_i[b]
+                        cx = c_ll * xb
+                        for a in b:p
+                            H[(l - 1) * p + a, col] += cx * x_i[a]
+                        end
+                        for j in (l + 1):k
+                            cjx = -wi * n_i * prob[j] * pl * xb
+                            for a in 1:p
+                                H[(j - 1) * p + a, col] += cjx * x_i[a]
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+    if H !== nothing
+        # Optim's Newton reads the full matrix — mirror the lower triangle.
+        d = k * p
+        for a in 1:d, b in (a + 1):d
+            H[a, b] = H[b, a]
+        end
+    end
+    G === nothing || neglogprior_grad!(o.prior, G, β)
+    H === nothing || neglogprior_hess!(o.prior, H, β)
+    F === nothing || return nll + neglogprior(o.prior, β)
+    return nothing
+end
+
+"""
+    MultinomialGLM{T<:Real, P<:AbstractPrior} <: AbstractGLM
+
+Multinomial logistic-regression emission for count vectors over `K` categories
+(softmax link, category `K` as the reference).
+
+For input x ∈ ℝᵖ the category probabilities are
+`p_j(x) = exp(ηⱼ) / Σₗ exp(ηₗ)` with `ηⱼ = B[:,j]ᵀ x` for `j < K` and `η_K = 0`.
+Observations are length-`K` integer count vectors; `logdensityof` and `fit!`
+condition on each observation's own total count, so totals may vary across
+time steps. `rand` draws a count vector with `n_trials` trials.
+
+`fit!` minimizes the weighted negative log-posterior via Optim's Newton method
+over the full `(K-1)·p` coefficient vector, with analytic gradient and
+Hessian (including the cross-category blocks) supplied through a fused `fgh!`.
+
+!!! note
+    As with logistic regression, linearly separable categories make the
+    unpenalized MLE diverge. Use a `RidgePrior(λ)` to keep the fit finite in
+    that regime.
+
+# Fields
+- `B`: coefficient matrix of size `p × (K-1)`; the reference category `K` has
+  coefficients pinned at zero
+- `n_trials`: number of trials drawn by `rand` (`n_trials ≥ 1`; not used by
+  `logdensityof`/`fit!`)
+- `prior`: regularization prior on `B` (default `NoPrior()`)
+"""
+mutable struct MultinomialGLM{T<:Real,P<:AbstractPrior} <: AbstractGLM
+    B::Matrix{T}
+    n_trials::Int
+    prior::P
+    in_dim::Int
+    out_dim::Int
+
+    function MultinomialGLM{T,P}(
+        B::Matrix{T}, n_trials::Int, prior::P, in_dim::Int, out_dim::Int
+    ) where {T<:Real,P<:AbstractPrior}
+        return new{T,P}(B, n_trials, prior, in_dim, out_dim)
+    end
+end
+
+function MultinomialGLM(
+    B::AbstractMatrix{T}, n_trials::Integer, prior::P
+) where {T<:AbstractFloat,P<:AbstractPrior}
+    p, k = size(B)
+    p > 0 || throw(ArgumentError("B must have at least one row"))
+    k > 0 || throw(ArgumentError("B must have at least one column"))
+    n_trials ≥ 1 || throw(ArgumentError("n_trials must be at least 1, got $n_trials"))
+    return MultinomialGLM{T,P}(Matrix{T}(B), Int(n_trials), prior, p, k + 1)
+end
+function MultinomialGLM(B::AbstractMatrix{T}, n_trials::Integer) where {T<:AbstractFloat}
+    return MultinomialGLM(B, n_trials, NoPrior())
+end
+
+function MultinomialGLM(B::AbstractMatrix, n_trials::Integer, prior::AbstractPrior)
+    T = float(eltype(B))
+    return MultinomialGLM(convert(Matrix{T}, B), n_trials, prior)
+end
+function MultinomialGLM(B::AbstractMatrix, n_trials::Integer)
+    return MultinomialGLM(B, n_trials, NoPrior())
+end
+
+#= Counts are accepted as any Real (integer-valued floats are common in HMM
+   obs sequences); vectors with negative or non-integer entries have zero
+   mass. The pmf conditions on the observation's own total count n = Σⱼ yⱼ:
+   log P(y|x) = log n! − Σⱼ log yⱼ! + Σⱼ yⱼ ηⱼ − n·logΣₗ exp(ηₗ). =#
+function DensityInterface.logdensityof(
+    glm::MultinomialGLM, y::AbstractVector; control_seq::AbstractVector{<:Real}
+)
+    length(y) == glm.out_dim ||
+        throw(DimensionMismatch("y length $(length(y)) ≠ out_dim $(glm.out_dim)"))
+    length(control_seq) == glm.in_dim || throw(
+        DimensionMismatch(
+            "control_seq length $(length(control_seq)) ≠ in_dim $(glm.in_dim)"
+        ),
+    )
+
+    Tη = float(promote_type(eltype(glm.B), eltype(control_seq)))
+    n_tot = 0
+    for yj in y
+        (yj >= 0 && isinteger(yj)) || return Tη(-Inf)
+        n_tot += Int(yj)
+    end
+
+    lse = zero(Tη)   # reference category contributes exp(0)
+    ydotη = zero(Tη)
+    lgm = zero(Tη)
+    for j in 1:(glm.out_dim - 1)
+        η = zero(Tη)
+        for r in 1:(glm.in_dim)
+            η += glm.B[r, j] * control_seq[r]
+        end
+        lse = logaddexp(lse, η)
+        yj = Int(y[j])
+        if yj > 0
+            ydotη += Tη(yj) * η
+            lgm += Tη(loggamma(yj + 1))
+        end
+    end
+    yK = Int(y[glm.out_dim])
+    yK > 0 && (lgm += Tη(loggamma(yK + 1)))
+
+    return Tη(loggamma(n_tot + 1)) - lgm + ydotη - Tη(n_tot) * lse
+end
+
+function Random.rand(
+    rng::AbstractRNG, glm::MultinomialGLM; control_seq::AbstractVector{<:Real}
+)
+    out = Vector{Int}(undef, glm.out_dim)
+    rand!(rng, glm, out; control_seq=control_seq)
+    return out
+end
+
+"""
+    rand!(rng, glm::MultinomialGLM, out; control_seq)
+
+In-place sample of a count vector with `n_trials` trials. `out` must be a
+length-`out_dim` integer vector. Zero allocation: uses the sequential
+conditional-binomial method, drawing each category's count from
+`Binomial(n_remaining, pⱼ / p_remaining)`.
+"""
+function Random.rand!(
+    rng::AbstractRNG,
+    glm::MultinomialGLM,
+    out::AbstractVector;
+    control_seq::AbstractVector{<:Real},
+)
+    length(out) == glm.out_dim ||
+        throw(DimensionMismatch("out length $(length(out)) ≠ out_dim $(glm.out_dim)"))
+    length(control_seq) == glm.in_dim || throw(
+        DimensionMismatch(
+            "control_seq length $(length(control_seq)) ≠ in_dim $(glm.in_dim)"
+        ),
+    )
+
+    T = float(promote_type(eltype(glm.B), eltype(control_seq)))
+    K = glm.out_dim
+
+    lse = zero(T)
+    for j in 1:(K - 1)
+        η = zero(T)
+        for r in 1:(glm.in_dim)
+            η += glm.B[r, j] * control_seq[r]
+        end
+        lse = logaddexp(lse, η)
+    end
+
+    n_rem = glm.n_trials
+    p_rem = one(T)
+    for j in 1:(K - 1)
+        if n_rem == 0
+            out[j] = 0
+            continue
+        end
+        η = zero(T)
+        for r in 1:(glm.in_dim)
+            η += glm.B[r, j] * control_seq[r]
+        end
+        pj = exp(η - lse)
+        # p_rem can undershoot 0 by rounding once most mass is spent.
+        pc = p_rem > 0 ? clamp(pj / p_rem, zero(T), one(T)) : one(T)
+        c = rand(rng, Binomial(n_rem, Float64(pc)))
+        out[j] = c
+        n_rem -= c
+        p_rem -= pj
+    end
+    out[K] = n_rem
+    return out
+end
+
+"""
+    fit!(glm::MultinomialGLM, obs_seq, weight_seq;
+         control_seq, max_iter=50, gtol=1e-8)
+
+Minimize the weighted negative log-posterior via Optim's Newton method over
+the flattened `p × (K-1)` coefficient matrix. Each observation `obs_seq[i]`
+must be a length-`K` vector of non-negative counts; totals may vary across
+observations. Gradient and Hessian (with cross-category blocks) are analytic,
+supplied through a fused `fgh!`.
+"""
+function StatsAPI.fit!(
+    glm::MultinomialGLM{T},
+    obs_seq::AbstractVector{<:AbstractVector},
+    weight_seq::AbstractVector{<:Real};
+    control_seq::AbstractMatrix{<:Real},
+    max_iter::Int=50,
+    gtol::Real=1e-8,
+) where {T<:Real}
+    n, p = size(control_seq)
+    length(obs_seq) == n ||
+        throw(DimensionMismatch("obs_seq length $(length(obs_seq)) ≠ control_seq rows $n"))
+    length(weight_seq) == n || throw(
+        DimensionMismatch("weight_seq length $(length(weight_seq)) ≠ control_seq rows $n"),
+    )
+    p == glm.in_dim ||
+        throw(DimensionMismatch("control_seq columns $p ≠ in_dim $(glm.in_dim)"))
+
+    K = glm.out_dim
+    for i in 1:n
+        length(obs_seq[i]) == K || throw(
+            DimensionMismatch("obs_seq[$i] length $(length(obs_seq[i])) ≠ out_dim $K")
+        )
+    end
+
+    k = K - 1
+    # β is the column-major flattening of B, so copyto! round-trips exactly.
+    β = Vector{T}(undef, p * k)
+    copyto!(β, glm.B)
+    fgh = _MultinomialFGH(
+        obs_seq, weight_seq, control_seq, glm.prior, k, Vector{T}(undef, k)
+    )
+    _newton_fit!(β, fgh; max_iter=max_iter, gtol=gtol)
+    copyto!(glm.B, β)
+    return glm
+end
+
 #= HiddenMarkovModels.ControlledEmission interface.
 
    `AbstractGLM <: ControlledEmission`, so a `Vector` of GLMs is a valid `dists`
@@ -1148,7 +1471,7 @@ end
 
 # Length of one covariate vector for this GLM (the GLM's input dimension `p`).
 _indim(glm::Union{GaussianGLM,BernoulliGLM,PoissonGLM}) = length(glm.β)
-_indim(glm::Union{MvGaussianGLM,MvBernoulliGLM,MvPoissonGLM}) = glm.in_dim
+_indim(glm::Union{MvGaussianGLM,MvBernoulliGLM,MvPoissonGLM,MultinomialGLM}) = glm.in_dim
 
 function DensityInterface.logdensityof(
     glm::AbstractGLM, obs, control::AbstractVector{<:Real}

--- a/src/glms/glm.jl
+++ b/src/glms/glm.jl
@@ -1254,6 +1254,10 @@ Observations are length-`K` integer count vectors; `logdensityof` and `fit!`
 condition on each observation's own total count, so totals may vary across
 time steps. `rand` draws a count vector with `n_trials` trials.
 
+For single-trial choice data, `logdensityof` and `fit!` also accept plain
+integer labels `y ∈ 1:K` (treated as one-hot count vectors), so a choice
+sequence can stay a `Vector{Int}` with no encoding step.
+
 `fit!` minimizes the weighted negative log-posterior via Optim's Newton method
 over the full `(K-1)·p` coefficient vector, with analytic gradient and
 Hessian (including the cross-category blocks) supplied through a fused `fgh!`.
@@ -1346,6 +1350,35 @@ function DensityInterface.logdensityof(
     yK > 0 && (lgm += Tη(loggamma(yK + 1)))
 
     return Tη(loggamma(n_tot + 1)) - lgm + ydotη - Tη(n_tot) * lse
+end
+
+#= Label form for single-trial choice data: `y ∈ 1:K` is the chosen category,
+   scored as its one-hot count vector, i.e. log p_y(x) = η_y − logΣₗ exp(ηₗ).
+   Non-integer or out-of-range labels have zero mass. =#
+function DensityInterface.logdensityof(
+    glm::MultinomialGLM, y::Real; control_seq::AbstractVector{<:Real}
+)
+    length(control_seq) == glm.in_dim || throw(
+        DimensionMismatch(
+            "control_seq length $(length(control_seq)) ≠ in_dim $(glm.in_dim)"
+        ),
+    )
+
+    Tη = float(promote_type(eltype(glm.B), eltype(control_seq)))
+    (isinteger(y) && 1 <= y <= glm.out_dim) || return Tη(-Inf)
+    k = Int(y)
+
+    lse = zero(Tη)   # reference category contributes exp(0)
+    η_k = zero(Tη)   # stays 0 when k is the reference
+    for j in 1:(glm.out_dim - 1)
+        η = zero(Tη)
+        for r in 1:(glm.in_dim)
+            η += glm.B[r, j] * control_seq[r]
+        end
+        lse = logaddexp(lse, η)
+        j == k && (η_k = η)
+    end
+    return η_k - lse
 end
 
 function Random.rand(
@@ -1457,6 +1490,51 @@ function StatsAPI.fit!(
     _newton_fit!(β, fgh; max_iter=max_iter, gtol=gtol)
     copyto!(glm.B, β)
     return glm
+end
+
+#= Lazy one-hot views: present a label sequence `y ∈ 1:K` as the sequence of
+   length-K count vectors e_y the multinomial machinery consumes, without
+   materializing an n × K matrix. =#
+struct _OneHot <: AbstractVector{Int}
+    k::Int
+    K::Int
+end
+Base.size(o::_OneHot) = (o.K,)
+Base.IndexStyle(::Type{_OneHot}) = IndexLinear()
+Base.getindex(o::_OneHot, j::Integer) = Int(j == o.k)
+
+struct _OneHotSeq{V<:AbstractVector{<:Real}} <: AbstractVector{_OneHot}
+    labels::V
+    K::Int
+end
+Base.size(s::_OneHotSeq) = (length(s.labels),)
+Base.IndexStyle(::Type{<:_OneHotSeq}) = IndexLinear()
+Base.getindex(s::_OneHotSeq, i::Integer) = _OneHot(Int(s.labels[i]), s.K)
+
+#= Label form of `fit!` for single-trial choice data: each observation is a
+   category label `y ∈ 1:K`, fit as its one-hot count vector through the
+   count-vector method above. =#
+function StatsAPI.fit!(
+    glm::MultinomialGLM,
+    obs_seq::AbstractVector{<:Real},
+    weight_seq::AbstractVector{<:Real};
+    control_seq::AbstractMatrix{<:Real},
+    max_iter::Int=50,
+    gtol::Real=1e-8,
+)
+    K = glm.out_dim
+    for y in obs_seq
+        (isinteger(y) && 1 <= y <= K) ||
+            throw(ArgumentError("observations must be labels in 1:$K, got $y"))
+    end
+    return fit!(
+        glm,
+        _OneHotSeq(obs_seq, K),
+        weight_seq;
+        control_seq=control_seq,
+        max_iter=max_iter,
+        gtol=gtol,
+    )
 end
 
 #= HiddenMarkovModels.ControlledEmission interface.

--- a/test/acdc/test_acdc.jl
+++ b/test/acdc/test_acdc.jl
@@ -195,6 +195,17 @@ end
     @test compute_discrepancy(KSDiscrepancy(), En) < 0.05
     @test abs(Statistics.cov(En[1, :], En[2, :])) < 0.01
 
+    # Label form: a single-trial label recovers the same drivers as its one-hot.
+    mn1 = MultinomialGLM([0.5 -0.3; 1.0 0.2; -0.6 0.7], 1)
+    El = Matrix{Float64}(undef, 2, N)
+    for i in 1:N
+        x = mkx()
+        label = findfirst(==(1), rand(rng, mn1; control_seq=x))
+        El[:, i] = EM._emission_to_driver(rng, mn1, label, x)
+    end
+    @test all(0 .<= El .<= 1)
+    @test compute_discrepancy(KSDiscrepancy(), El) < 0.05
+
     # The covariate-free form on a GLM errors; a covariate is required.
     @test_throws ArgumentError EM._emission_to_driver(rng, GaussianGLM([0.5], 1.0), 1.0)
 end

--- a/test/acdc/test_acdc.jl
+++ b/test/acdc/test_acdc.jl
@@ -181,6 +181,20 @@ end
         @test abs(Statistics.cov(E[1, :], E[2, :])) < 0.01
     end
 
+    #= MultinomialGLM: conditional-binomial Rosenblatt drivers. The count
+       coordinates are dependent through the shared total, so beyond uniform
+       marginals the drivers must come out independent. K = 3 gives K−1 = 2
+       driver dimensions. =#
+    mn = MultinomialGLM([0.5 -0.3; 1.0 0.2; -0.6 0.7], 5)
+    En = Matrix{Float64}(undef, 2, N)
+    for i in 1:N
+        x = mkx()
+        En[:, i] = EM._emission_to_driver(rng, mn, rand(rng, mn; control_seq=x), x)
+    end
+    @test all(0 .<= En .<= 1)
+    @test compute_discrepancy(KSDiscrepancy(), En) < 0.05
+    @test abs(Statistics.cov(En[1, :], En[2, :])) < 0.01
+
     # The covariate-free form on a GLM errors; a covariate is required.
     @test_throws ArgumentError EM._emission_to_driver(rng, GaussianGLM([0.5], 1.0), 1.0)
 end

--- a/test/allocations.jl
+++ b/test/allocations.jl
@@ -209,6 +209,32 @@ s)
         @test (@allocated fit!(zip2, y, w)) ≤ 1_000
     end
 
+    @testset "MultinomialGLM" begin
+        x = [1.0, 2.0]
+        # p = 2 inputs, K = 3 categories (B is p × K-1), 6 trials per draw.
+        mn = MultinomialGLM([0.5 -1.0; 0.2 0.3], 6)
+        yv = [3, 2, 1]
+
+        bench_logd(mn, yv, x, 1)
+        @test (@allocated bench_logd(mn, yv, x, REPS)) <= ALLOC_SLOP
+
+        # rand! into a pre-allocated buffer — zero alloc.
+        out = zeros(Int, 3)
+        bench_rand!_i(rng, mn, out, x, 1)
+        @test (@allocated bench_rand!_i(rng, mn, out, x, REPS)) <= ALLOC_SLOP
+
+        #= fit!: Newton over the flattened (K-1)·p coefficients — Optim solver
+           state is O(((K-1)p)²), independent of n. =#
+        n = 500
+        X = hcat(ones(n), randn(rng, n))
+        w = ones(n)
+        ymn = [rand(rng, mn; control_seq=view(X, i, :)) for i in 1:n]
+        gmn = MultinomialGLM(zeros(2, 2), 6)
+        fit!(gmn, ymn, w; control_seq=X)
+        gmn = MultinomialGLM(zeros(2, 2), 6)
+        @test (@allocated fit!(gmn, ymn, w; control_seq=X)) ≤ 40_000
+    end
+
     @testset "MultivariateT (full Σ)" begin
         d = 2
         mvt = MultivariateT([0.0, 0.0], [1.0 0.3; 0.3 1.0], 5.0)

--- a/test/glm/test_controlled_hmm.jl
+++ b/test/glm/test_controlled_hmm.jl
@@ -19,6 +19,7 @@ using Test
             GaussianGLM,
             BernoulliGLM,
             PoissonGLM,
+            MultinomialGLM,
             MvGaussianGLM,
             MvBernoulliGLM,
             MvPoissonGLM,

--- a/test/glm/test_multinomial.jl
+++ b/test/glm/test_multinomial.jl
@@ -1,0 +1,222 @@
+using EmissionModels
+using Test
+using Random
+using DensityInterface
+using StatsAPI
+using SpecialFunctions: loggamma
+using Statistics: mean
+using LinearAlgebra
+using HiddenMarkovModels
+using HiddenMarkovModels: ControlledEmissionHMM, baum_welch, forward
+
+import StatsAPI: fit!
+
+#= Reference softmax probabilities for a p × (K-1) coefficient matrix and a
+   single control vector, with category K as the reference (η_K = 0). =#
+function _softmax_probs(B, x)
+    η = vcat(vec(x' * B), 0.0)
+    e = exp.(η .- maximum(η))
+    return e ./ sum(e)
+end
+
+#= Explicit multinomial log-pmf at count vector y with probabilities p. =#
+function _multinomial_logpmf(y, p)
+    n = sum(y)
+    return loggamma(n + 1) - sum(loggamma.(y .+ 1)) +
+           sum(yk * log(pk) for (yk, pk) in zip(y, p) if yk > 0)
+end
+
+@testset "MultinomialGLM" begin
+    @testset "Constructor" begin
+        B = [0.5 -1.0; 0.2 0.3]  # p = 2, K - 1 = 2
+        glm = MultinomialGLM(B, 5)
+        @test glm.B == B
+        @test glm.n_trials == 5
+        @test glm.in_dim == 2
+        @test glm.out_dim == 3
+        @test glm.prior isa NoPrior
+
+        # Prior-carrying constructor
+        glm_r = MultinomialGLM(B, 5, RidgePrior(0.5))
+        @test glm_r.prior isa RidgePrior
+
+        # Promoting fallback for integer eltype
+        glm_i = MultinomialGLM([1 0; 0 1], 3)
+        @test glm_i.B isa Matrix{Float64}
+
+        # Invalid parameters
+        @test_throws ArgumentError MultinomialGLM(zeros(0, 2), 5)
+        @test_throws ArgumentError MultinomialGLM(zeros(2, 0), 5)
+        @test_throws ArgumentError MultinomialGLM(B, 0)
+    end
+
+    @testset "logdensityof matches explicit pmf" begin
+        rng = Random.MersenneTwister(1)
+        B = [0.8 -0.4; -0.5 0.9; 0.2 0.1]  # p = 3, K = 3
+        glm = MultinomialGLM(B, 6)
+
+        for _ in 1:20
+            x = vcat(1.0, randn(rng, 2))
+            probs = _softmax_probs(B, x)
+            for y in ([6, 0, 0], [2, 2, 2], [0, 1, 5], [1, 1, 1])
+                expected = _multinomial_logpmf(y, probs)
+                @test logdensityof(glm, y; control_seq=x) ≈ expected rtol = 1e-10
+            end
+        end
+    end
+
+    @testset "logdensityof edge cases" begin
+        glm = MultinomialGLM([0.5 -1.0; 0.2 0.3], 5)
+        x = [1.0, 0.5]
+
+        # Counts stored as floats score identically
+        @test logdensityof(glm, [2.0, 2.0, 1.0]; control_seq=x) ==
+            logdensityof(glm, [2, 2, 1]; control_seq=x)
+
+        #= Totals may differ from n_trials: the pmf conditions on the
+           observation's own total. =#
+        @test isfinite(logdensityof(glm, [1, 0, 0]; control_seq=x))
+        @test isfinite(logdensityof(glm, [4, 4, 4]; control_seq=x))
+        # The empty count vector has probability 1.
+        @test logdensityof(glm, [0, 0, 0]; control_seq=x) == 0.0
+
+        # Zero-mass observations
+        @test logdensityof(glm, [3, -1, 3]; control_seq=x) == -Inf
+        @test logdensityof(glm, [2.5, 2.5, 0.0]; control_seq=x) == -Inf
+
+        # Dimension mismatches are programming errors
+        @test_throws DimensionMismatch logdensityof(glm, [2, 3]; control_seq=x)
+        @test_throws DimensionMismatch logdensityof(glm, [2, 2, 1]; control_seq=[1.0])
+    end
+
+    @testset "K = 2 reduces to Bernoulli logistic for one-hot counts" begin
+        rng = Random.MersenneTwister(2)
+        β = [0.7, -1.2]
+        glm = MultinomialGLM(reshape(β, 2, 1), 1)
+        blm = BernoulliGLM(β)
+        for _ in 1:10
+            x = vcat(1.0, randn(rng))
+            @test logdensityof(glm, [1, 0]; control_seq=x) ≈
+                logdensityof(blm, 1; control_seq=x) rtol = 1e-12
+            @test logdensityof(glm, [0, 1]; control_seq=x) ≈
+                logdensityof(blm, 0; control_seq=x) rtol = 1e-12
+        end
+    end
+
+    @testset "Random sampling" begin
+        rng = Random.MersenneTwister(42)
+        B = [0.5 -1.0; 0.2 0.3]
+        n_trials = 8
+        glm = MultinomialGLM(B, n_trials)
+        x = [1.0, 0.5]
+        probs = _softmax_probs(B, x)
+
+        n_samples = 5000
+        samples = [rand(rng, glm; control_seq=x) for _ in 1:n_samples]
+
+        @test all(sum(s) == n_trials for s in samples)
+        @test all(all(≥(0), s) for s in samples)
+        @test all(s isa Vector{Int} for s in samples)
+
+        # Marginal means are n_trials * p_k
+        for k in 1:3
+            @test mean(s[k] for s in samples) ≈ n_trials * probs[k] atol = 0.15
+        end
+
+        # In-place sampling
+        out = zeros(Int, 3)
+        rand!(rng, glm, out; control_seq=x)
+        @test sum(out) == n_trials
+        @test_throws DimensionMismatch rand!(rng, glm, zeros(Int, 2); control_seq=x)
+        @test_throws DimensionMismatch rand!(rng, glm, out; control_seq=[1.0])
+
+        # Positional ControlledEmission adapter matches the keyword path
+        @test rand(Random.MersenneTwister(7), glm, x) ==
+            rand(Random.MersenneTwister(7), glm; control_seq=x)
+    end
+
+    @testset "fit! recovers coefficients" begin
+        rng = Random.MersenneTwister(123)
+        n, p = 3000, 2
+        B_true = [1.0 -0.5; -0.8 0.6]  # K = 3
+        n_trials = 5
+        gen = MultinomialGLM(B_true, n_trials)
+
+        X = hcat(ones(n), randn(rng, n))
+        obs = [rand(rng, gen; control_seq=view(X, i, :)) for i in 1:n]
+        w = ones(n)
+
+        fitted = MultinomialGLM(zeros(p, 2), n_trials)
+        fit!(fitted, obs, w; control_seq=X)
+        @test fitted.B ≈ B_true atol = 0.15
+
+        # Positional vector-of-vectors control path matches the matrix path
+        Xvv = [X[i, :] for i in 1:n]
+        fitted_pos = MultinomialGLM(zeros(p, 2), n_trials)
+        fit!(fitted_pos, obs, Xvv, w)
+        @test fitted_pos.B ≈ fitted.B rtol = 1e-8
+    end
+
+    @testset "fit! respects weights and priors" begin
+        rng = Random.MersenneTwister(456)
+        n, p = 500, 2
+        B_true = [0.6 -0.4; -0.3 0.8]
+        gen = MultinomialGLM(B_true, 4)
+        X = hcat(ones(2n), randn(rng, 2n))
+        obs = [rand(rng, gen; control_seq=view(X, i, :)) for i in 1:(2n)]
+
+        #= Zero-weight observations must not influence the fit: fitting the
+           full data with the second half zero-weighted equals fitting the
+           first half alone. =#
+        w_half = vcat(ones(n), zeros(n))
+        g_masked = MultinomialGLM(zeros(p, 2), 4)
+        fit!(g_masked, obs, w_half; control_seq=X)
+        g_subset = MultinomialGLM(zeros(p, 2), 4)
+        fit!(g_subset, obs[1:n], ones(n); control_seq=X[1:n, :])
+        @test g_masked.B ≈ g_subset.B rtol = 1e-6
+
+        # Ridge shrinks the coefficients toward zero
+        g_mle = MultinomialGLM(zeros(p, 2), 4)
+        fit!(g_mle, obs, ones(2n); control_seq=X)
+        g_ridge = MultinomialGLM(zeros(p, 2), 4, RidgePrior(50.0))
+        fit!(g_ridge, obs, ones(2n); control_seq=X)
+        @test norm(g_ridge.B) < norm(g_mle.B)
+    end
+
+    @testset "fit! dimension errors" begin
+        glm = MultinomialGLM(zeros(2, 2), 5)
+        X = ones(4, 2)
+        obs = [[1, 1, 3] for _ in 1:4]
+        @test_throws DimensionMismatch fit!(glm, obs[1:3], ones(4); control_seq=X)
+        @test_throws DimensionMismatch fit!(glm, obs, ones(3); control_seq=X)
+        @test_throws DimensionMismatch fit!(glm, obs, ones(4); control_seq=ones(4, 3))
+        bad_obs = [[1, 1, 3], [1, 1], [1, 1, 3], [1, 1, 3]]
+        @test_throws DimensionMismatch fit!(glm, bad_obs, ones(4); control_seq=X)
+    end
+
+    @testset "ControlledEmissionHMM: sample, forward, baum_welch" begin
+        rng = Random.MersenneTwister(777)
+        p, T = 2, 800
+        init = [0.6, 0.4]
+        trans = [0.92 0.08; 0.15 0.85]
+        dists = [
+            MultinomialGLM([1.0 -0.6; -0.5 0.4], 5), MultinomialGLM([-1.0 0.8; 0.6 -0.3], 5)
+        ]
+        hmm = ControlledEmissionHMM(init, trans, dists)
+
+        control_seq = [vcat(1.0, randn(rng)) for _ in 1:T]
+        obs_seq = rand(rng, hmm, control_seq).obs_seq
+        @test length(obs_seq) == T
+        @test all(sum(obs) == 5 for obs in obs_seq)
+
+        logL = last(forward(hmm, obs_seq, control_seq; seq_ends=[T]))
+        @test all(isfinite, logL)
+
+        # fit from a perturbed start; baum_welch must be (weakly) monotone
+        dists0 = [MultinomialGLM(zeros(p, 2), 5), MultinomialGLM(zeros(p, 2), 5)]
+        hmm0 = ControlledEmissionHMM([0.5, 0.5], copy(trans), dists0)
+        _, lls = baum_welch(hmm0, obs_seq, control_seq; seq_ends=[T], max_iterations=20)
+        @test all(diff(lls) .>= -1e-6)
+        @test last(lls) >= first(lls)
+    end
+end

--- a/test/glm/test_multinomial.jl
+++ b/test/glm/test_multinomial.jl
@@ -103,6 +103,71 @@ end
         end
     end
 
+    @testset "Integer labels are one-hot sugar" begin
+        rng = Random.MersenneTwister(3)
+        B = [0.8 -0.4; -0.5 0.9; 0.2 0.1]  # p = 3, K = 3
+        glm = MultinomialGLM(B, 1)
+
+        onehot(k) = [Int(j == k) for j in 1:3]
+        for _ in 1:10
+            x = vcat(1.0, randn(rng, 2))
+            for k in 1:3
+                @test logdensityof(glm, k; control_seq=x) ==
+                    logdensityof(glm, onehot(k); control_seq=x)
+            end
+        end
+
+        # Softmax probabilities across labels sum to 1
+        x = vcat(1.0, randn(rng, 2))
+        @test sum(exp(logdensityof(glm, k; control_seq=x)) for k in 1:3) ≈ 1.0
+
+        # Invalid labels have zero mass
+        @test logdensityof(glm, 0; control_seq=x) == -Inf
+        @test logdensityof(glm, 4; control_seq=x) == -Inf
+        @test logdensityof(glm, 1.5; control_seq=x) == -Inf
+        @test_throws DimensionMismatch logdensityof(glm, 2; control_seq=[1.0])
+
+        # fit! on labels matches fit! on the equivalent one-hot vectors
+        n = 1500
+        X = hcat(ones(n), randn(rng, n), randn(rng, n))
+        labels = [findfirst(==(1), rand(rng, glm; control_seq=view(X, i, :))) for i in 1:n]
+        w = ones(n)
+        g_labels = MultinomialGLM(zeros(3, 2), 1)
+        fit!(g_labels, labels, w; control_seq=X)
+        g_onehot = MultinomialGLM(zeros(3, 2), 1)
+        fit!(g_onehot, [onehot(l) for l in labels], w; control_seq=X)
+        @test g_labels.B ≈ g_onehot.B rtol = 1e-8
+
+        # Out-of-range labels throw and leave the model intact
+        g_bad = MultinomialGLM(zeros(3, 2), 1)
+        @test_throws ArgumentError fit!(g_bad, [1, 4, 2], ones(3); control_seq=X[1:3, :])
+        @test g_bad.B == zeros(3, 2)
+    end
+
+    @testset "Label-valued ControlledEmissionHMM" begin
+        rng = Random.MersenneTwister(11)
+        p, T = 2, 800
+        trans = [0.92 0.08; 0.15 0.85]
+        dists = [
+            MultinomialGLM([1.2 -0.8; -0.6 0.5], 1), MultinomialGLM([-1.2 0.9; 0.7 -0.4], 1)
+        ]
+        hmm = ControlledEmissionHMM([0.6, 0.4], trans, dists)
+
+        control_seq = [vcat(1.0, randn(rng)) for _ in 1:T]
+        # Simulated one-hot counts, stored as the label sequence a user would have.
+        obs_seq = [findfirst(==(1), o) for o in rand(rng, hmm, control_seq).obs_seq]
+        @test obs_seq isa Vector{Int}
+        @test all(o -> o in 1:3, obs_seq)
+
+        logL = last(forward(hmm, obs_seq, control_seq; seq_ends=[T]))
+        @test all(isfinite, logL)
+
+        dists0 = [MultinomialGLM(zeros(p, 2), 1), MultinomialGLM(zeros(p, 2), 1)]
+        hmm0 = ControlledEmissionHMM([0.5, 0.5], copy(trans), dists0)
+        _, lls = baum_welch(hmm0, obs_seq, control_seq; seq_ends=[T], max_iterations=20)
+        @test all(diff(lls) .>= -1e-6)
+    end
+
     @testset "Random sampling" begin
         rng = Random.MersenneTwister(42)
         B = [0.5 -1.0; 0.2 0.3]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,7 @@ using JuliaFormatter
         include("glm/gaussian.jl")
         include("glm/test_bernoulli_poisson.jl")
         include("glm/test_promotion_and_types.jl")
+        include("glm/test_multinomial.jl")
         include("glm/test_controlled_hmm.jl")
     end
     @testset "Zero-inflated models" begin


### PR DESCRIPTION
Resolves #23 

- Add a `MultinomialGLM`
- Support for model selection via `ACDC`
- Syntactic sugar so can pass a `vector` of labels in the `n=1` case