### PR TITLE
Make benchmark script tolerant of the MvT rename

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -8,6 +8,14 @@ include(joinpath(@__DIR__, "utils.jl"))
 
 using LinearAlgebra: I
 
+#= benchpkg runs this script (the `--bench-on=main` copy) against every
+   revision it compares, so it must load on revisions where the API freeze
+   (#55) renamed MultivariateT/MultivariateTDiag to MvT/MvTDiag. =#
+if !isdefined(EmissionModels, :MultivariateT)
+    const MultivariateT = EmissionModels.MvT
+    const MultivariateTDiag = EmissionModels.MvTDiag
+end
+
 const SUITE = BenchmarkGroup()
 
 rng = Random.MersenneTwister(0)


### PR DESCRIPTION
The `bench` job on #55 fails with `UndefVarError: MultivariateT not defined`: benchpkg runs the `--bench-on=main` copy of `benchmark/benchmarks.jl` against every revision it compares, and #55 renames `MultivariateT`/`MultivariateTDiag` to `MvT`/`MvTDiag`, so main's script cannot load on the PR revision.

This aliases the old names when they are absent, so the script loads on both sides of the rename. #55 only touches the usage lines, so the two branches merge cleanly in either order. Once this lands, re-running the bench job on #55 should go green.