### PR TITLE
Release polish for 0.1.0 (changelog, license, docs, CI)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,6 +15,9 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
+    # Prerelease Julia shifts GC/inlining, which can trip the hard allocation
+    # budgets; let 'pre' fail without blocking the workflow and inspect by hand.
+    continue-on-error: ${{ matrix.version == 'pre' }}
     timeout-minutes: 60
     permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
       actions: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to EmissionModels.jl are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.0]
 
 Initial feature set, targeting the first registered release (0.1.0). Every
 emission type implements the same interface — `logdensityof`, `rand`/`rand!`,

--- a/README.md
+++ b/README.md
@@ -26,10 +26,14 @@ using HiddenMarkovModels
 # Create an emission model
 dist = PoissonZeroInflated(5.0, 0.3)
 
-# Sample, evaluate densities, or fit to data
+# Sample and evaluate densities
 x = rand(dist)
 logp = logdensityof(dist, x)
-fit!(dist, observations, weight_seq)
+
+# Fit to weighted observations (weights are HMM posterior state probabilities)
+obs_seq = [rand(dist) for _ in 1:100]
+weight_seq = ones(100)
+fit!(dist, obs_seq, weight_seq)
 ```
 
 ## Distribution models
@@ -149,4 +153,4 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 
 ## License
 
-EmissionModels.jl is licensed under the terms of the `LICENSE` file.
+EmissionModels.jl is released under the [MIT License](LICENSE).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -30,7 +30,8 @@ trans = [0.8 0.2; 0.3 0.7]
 emissions = [PoissonZeroInflated(5.0, 0.3), PoissonZeroInflated(20.0, 0.1)]
 hmm = HMM(init, trans, emissions)
 
-# Fit with Baum-Welch
+# Simulate a sequence, then fit with Baum-Welch
+_, obs_seq = rand(hmm, 500)
 hmm_est, loglik_trace = baum_welch(hmm, obs_seq)
 ```
 


### PR DESCRIPTION
First of three PRs from the full package review. This one is docs/CI only — no source changes.

### Changes
- **CHANGELOG**: promote the `Unreleased` section to `## [0.1.0]` so TagBot/registration tag against a real version heading. Date left blank until the tag date is known.
- **README**: name the MIT license explicitly (was "terms of the LICENSE file"); make the quick-start snippet self-contained (it referenced undefined `observations`/`weight_seq`).
- **docs/index.md**: quick-start `baum_welch` referenced an undefined `obs_seq`; now simulates one first.
- **CI**: `continue-on-error` for the `pre` Julia job so prerelease GC/inlining shifts that trip the hard allocation budgets don't block the workflow (inspect by hand when flagged).

### Follow-ups (separate PRs)
- PR2: Float32/Dual genericity + correctness fixes (`acdc_select` signature, KL `log_c_D`, poisson literals, `MvGaussianGLM.logdensityof`, GLM validation, SSM-ext `catch` narrowing) + tests.
- PR3: code-quality dedup (Bernoulli/Poisson functor merge, η helper, variance-floor helper) + infra (Windows/macOS CI, `@autodocs`, benchmark.yml hardening).